### PR TITLE
fix: SDK bug fixes, test coverage, and documentation improvements

### DIFF
--- a/Keycloak.Net.Sdk.IntegrationTests/Keycloak.Net.Sdk.IntegrationTests.csproj
+++ b/Keycloak.Net.Sdk.IntegrationTests/Keycloak.Net.Sdk.IntegrationTests.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Testcontainers.Keycloak" Version="4.12.0" />
+        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.1" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Keycloak.Net.Sdk\Keycloak.Net.Sdk.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Keycloak.Net.Sdk.IntegrationTests/KeycloakFixture.cs
+++ b/Keycloak.Net.Sdk.IntegrationTests/KeycloakFixture.cs
@@ -1,0 +1,239 @@
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+using DotNet.Testcontainers.Builders;
+using Keycloak.Net.Sdk.Configurations;
+using Keycloak.Net.Sdk.Contracts;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using Testcontainers.Keycloak;
+using Xunit;
+using KeycloakConfiguration = Keycloak.Net.Sdk.Configurations.KeycloakConfiguration;
+
+namespace Keycloak.Net.Sdk.IntegrationTests;
+
+/// <summary>
+/// Starts one Keycloak container for all integration tests in the collection.
+/// Setup sequence:
+///   1. Get master-realm admin token
+///   2. Create realm "sdk-integration"
+///   3. Create confidential client with service accounts
+///   4. Assign realm-admin role to service account → SDK can manage users/roles
+///   5. Create a test role inside the client
+///   6. Create a test user
+/// </summary>
+public class KeycloakFixture : IAsyncLifetime
+{
+    private KeycloakContainer _container = null!;
+
+    // ── Public state consumed by tests ────────────────────────────────────────
+    public IServiceProvider Services     { get; private set; } = null!;
+    public string           TestUserId   { get; private set; } = null!;
+    public string           TestRoleId   { get; private set; } = null!;
+    public const string     TestRoleName = "sdk-test-role";
+    public const string     TestUsername = "sdk-test-user";
+    public const string     TestPassword = "Test@1234";
+    public const string     Realm        = "sdk-integration";
+    public const string     SdkClientId  = "sdk-client";
+
+    private const string AdminUsername = "admin";
+    private const string AdminPassword = "admin";
+
+    public async Task InitializeAsync()
+    {
+        _container = new KeycloakBuilder().Build();
+        await _container.StartAsync();
+
+        var baseAddress = _container.GetBaseAddress().TrimEnd('/');
+        using var http  = new HttpClient { BaseAddress = new Uri(baseAddress + "/") };
+
+        // 1. Admin token in master realm
+        var adminToken = await GetAdminTokenAsync(http);
+
+        // 2. Create test realm
+        await CreateRealmAsync(http, adminToken, Realm);
+
+        // 3. Create SDK client (confidential + service accounts)
+        var clientUuid  = await CreateClientAsync(http, adminToken, Realm, SdkClientId);
+        var clientSecret = await GetClientSecretAsync(http, adminToken, Realm, clientUuid);
+
+        // 4. Give service account realm-admin role
+        await AssignRealmAdminToServiceAccountAsync(http, adminToken, Realm, clientUuid, SdkClientId);
+
+        // 5. Create test role inside the client
+        TestRoleId = await CreateClientRoleAsync(http, adminToken, Realm, clientUuid, TestRoleName);
+
+        // 6. Create test user
+        TestUserId = await CreateTestUserAsync(http, adminToken, Realm, TestUsername, TestPassword);
+
+        // 7. Wire up the SDK
+        var config = new KeycloakConfiguration
+        {
+            ServerUrl     = baseAddress + "/",
+            RealmName     = Realm,
+            ClientId      = SdkClientId,
+            ClientSecret  = clientSecret,
+            ClientUuid    = clientUuid,
+            AdminUsername = AdminUsername,
+            AdminPassword = AdminPassword,
+            NumberOfRetries = 1,
+            DelayBetweenRetryRequestsInSeconds = 1
+        };
+
+        var services = new ServiceCollection();
+        services.AddKeycloak(BuildConfigurationFrom(config));
+        Services = services.BuildServiceProvider();
+    }
+
+    public async Task DisposeAsync() => await _container.DisposeAsync();
+
+    // ── Admin API helpers ─────────────────────────────────────────────────────
+
+    private static async Task<string> GetAdminTokenAsync(HttpClient http)
+    {
+        var form = new FormUrlEncodedContent(new Dictionary<string, string>
+        {
+            ["client_id"]  = "admin-cli",
+            ["grant_type"] = "password",
+            ["username"]   = AdminUsername,
+            ["password"]   = AdminPassword
+        });
+        var resp = await http.PostAsync("realms/master/protocol/openid-connect/token", form);
+        resp.EnsureSuccessStatusCode();
+        var json = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        return json.RootElement.GetProperty("access_token").GetString()!;
+    }
+
+    private static async Task CreateRealmAsync(HttpClient http, string token, string realm)
+    {
+        var req = AuthorizedPost("admin/realms", token,
+            new { realm, enabled = true });
+        (await http.SendAsync(req)).EnsureSuccessStatusCode();
+    }
+
+    private static async Task<string> CreateClientAsync(HttpClient http, string token, string realm, string clientId)
+    {
+        var req = AuthorizedPost($"admin/realms/{realm}/clients", token,
+            new { clientId, enabled = true, publicClient = false, serviceAccountsEnabled = true, protocol = "openid-connect" });
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        // Location header contains the client URL: .../clients/{uuid}
+        var uuid = resp.Headers.Location!.ToString().Split('/').Last();
+        return uuid;
+    }
+
+    private static async Task<string> GetClientSecretAsync(HttpClient http, string token, string realm, string clientUuid)
+    {
+        var req = AuthorizedGet($"admin/realms/{realm}/clients/{clientUuid}/client-secret", token);
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        var json = JsonDocument.Parse(await resp.Content.ReadAsStringAsync());
+        return json.RootElement.GetProperty("value").GetString()!;
+    }
+
+    private static async Task AssignRealmAdminToServiceAccountAsync(
+        HttpClient http, string token, string realm, string clientUuid, string clientId)
+    {
+        // Get service account user
+        var saReq  = AuthorizedGet($"admin/realms/{realm}/clients/{clientUuid}/service-account-user", token);
+        var saResp = await http.SendAsync(saReq);
+        saResp.EnsureSuccessStatusCode();
+        var saJson = JsonDocument.Parse(await saResp.Content.ReadAsStringAsync());
+        var saUserId = saJson.RootElement.GetProperty("id").GetString()!;
+
+        // Get realm-management client uuid
+        var rmReq  = AuthorizedGet($"admin/realms/{realm}/clients?clientId=realm-management", token);
+        var rmResp = await http.SendAsync(rmReq);
+        rmResp.EnsureSuccessStatusCode();
+        var rmJson     = JsonDocument.Parse(await rmResp.Content.ReadAsStringAsync());
+        var rmClientUuid = rmJson.RootElement[0].GetProperty("id").GetString()!;
+
+        // Get realm-admin role
+        var roleReq  = AuthorizedGet($"admin/realms/{realm}/clients/{rmClientUuid}/roles/realm-admin", token);
+        var roleResp = await http.SendAsync(roleReq);
+        roleResp.EnsureSuccessStatusCode();
+        var roleJson = JsonDocument.Parse(await roleResp.Content.ReadAsStringAsync());
+        var roleId   = roleJson.RootElement.GetProperty("id").GetString()!;
+        var roleName = roleJson.RootElement.GetProperty("name").GetString()!;
+
+        // Assign role to service account
+        var assignReq = AuthorizedPost(
+            $"admin/realms/{realm}/users/{saUserId}/role-mappings/clients/{rmClientUuid}", token,
+            new[] { new { id = roleId, name = roleName } });
+        (await http.SendAsync(assignReq)).EnsureSuccessStatusCode();
+    }
+
+    private static async Task<string> CreateClientRoleAsync(
+        HttpClient http, string token, string realm, string clientUuid, string roleName)
+    {
+        var req  = AuthorizedPost($"admin/realms/{realm}/clients/{clientUuid}/roles", token, new { name = roleName });
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+
+        // Fetch the created role to get its ID
+        var getRoleReq  = AuthorizedGet($"admin/realms/{realm}/clients/{clientUuid}/roles/{roleName}", token);
+        var getRoleResp = await http.SendAsync(getRoleReq);
+        getRoleResp.EnsureSuccessStatusCode();
+        var json = JsonDocument.Parse(await getRoleResp.Content.ReadAsStringAsync());
+        return json.RootElement.GetProperty("id").GetString()!;
+    }
+
+    private static async Task<string> CreateTestUserAsync(
+        HttpClient http, string token, string realm, string username, string password)
+    {
+        var req = AuthorizedPost($"admin/realms/{realm}/users", token,
+            new
+            {
+                username,
+                enabled = true,
+                credentials = new[] { new { type = "password", value = password, temporary = false } }
+            });
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+        return resp.Headers.Location!.ToString().Split('/').Last();
+    }
+
+    // ── HTTP helpers ──────────────────────────────────────────────────────────
+
+    private static HttpRequestMessage AuthorizedPost(string url, string token, object body)
+    {
+        var msg = new HttpRequestMessage(HttpMethod.Post, url)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(body), Encoding.UTF8, "application/json")
+        };
+        msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return msg;
+    }
+
+    private static HttpRequestMessage AuthorizedGet(string url, string token)
+    {
+        var msg = new HttpRequestMessage(HttpMethod.Get, url);
+        msg.Headers.Authorization = new AuthenticationHeaderValue("Bearer", token);
+        return msg;
+    }
+
+    // ── IConfiguration shim ───────────────────────────────────────────────────
+
+    private static Microsoft.Extensions.Configuration.IConfiguration BuildConfigurationFrom(KeycloakConfiguration cfg)
+    {
+        var dict = new Dictionary<string, string?>
+        {
+            ["keycloak:ServerUrl"]                        = cfg.ServerUrl,
+            ["keycloak:RealmName"]                        = cfg.RealmName,
+            ["keycloak:ClientId"]                         = cfg.ClientId,
+            ["keycloak:ClientSecret"]                     = cfg.ClientSecret,
+            ["keycloak:ClientUuid"]                       = cfg.ClientUuid,
+            ["keycloak:AdminUsername"]                    = cfg.AdminUsername,
+            ["keycloak:AdminPassword"]                    = cfg.AdminPassword,
+            ["keycloak:NumberOfRetries"]                  = cfg.NumberOfRetries.ToString(),
+            ["keycloak:DelayBetweenRetryRequestsInSeconds"] = cfg.DelayBetweenRetryRequestsInSeconds.ToString()
+        };
+        return new Microsoft.Extensions.Configuration.ConfigurationBuilder()
+            .AddInMemoryCollection(dict)
+            .Build();
+    }
+}
+
+[CollectionDefinition(nameof(KeycloakCollection))]
+public class KeycloakCollection : ICollectionFixture<KeycloakFixture>;

--- a/Keycloak.Net.Sdk.IntegrationTests/SdkIntegrationTests.cs
+++ b/Keycloak.Net.Sdk.IntegrationTests/SdkIntegrationTests.cs
@@ -1,0 +1,211 @@
+using Keycloak.Net.Sdk.Contracts;
+using Keycloak.Net.Sdk.Users.Contracts;
+using Keycloak.Net.Sdk.Roles.Contracts;
+using Keycloak.Net.Sdk.Athentications.Contracts;
+using Keycloak.Net.Sdk.Clients.Contracts;
+using Keycloak.Net.Sdk.Realms;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace Keycloak.Net.Sdk.IntegrationTests;
+
+[Collection(nameof(KeycloakCollection))]
+public class UserManagementIntegrationTests(KeycloakFixture fixture)
+{
+    private IUserManagement User => fixture.Services.CreateScope().ServiceProvider.GetRequiredService<IUserManagement>();
+
+    [Fact]
+    public async Task SigninAsync_WithValidCredentials_ReturnsTokens()
+    {
+        var result = await User.SigninAsync(KeycloakFixture.TestUsername, KeycloakFixture.TestPassword);
+
+        Assert.True(result.IsSuccessful);
+        Assert.NotEmpty(result.Response.AccessToken!);
+        Assert.NotEmpty(result.Response.RefreshToken);
+        Assert.True(result.Response.ExpiresIn > 0);
+    }
+
+    [Fact]
+    public async Task SigninAsync_WithWrongPassword_ReturnsFailure()
+    {
+        var result = await User.SigninAsync(KeycloakFixture.TestUsername, "wrong-password");
+
+        Assert.False(result.IsSuccessful);
+    }
+
+    [Fact]
+    public async Task GetUserAsync_WithValidId_ReturnsCorrectUser()
+    {
+        var result = await User.GetUserAsync(fixture.TestUserId);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(fixture.TestUserId, result.Response.Id);
+        Assert.Equal(KeycloakFixture.TestUsername, result.Response.Username);
+    }
+
+    [Fact]
+    public async Task GetUserByUsernameAsync_WithValidUsername_ReturnsUser()
+    {
+        var result = await User.GetUserByUsernameAsync(KeycloakFixture.TestUsername);
+
+        Assert.True(result.IsSuccessful);
+        Assert.NotEmpty(result.Response);
+        Assert.Contains(result.Response, u => u.Username == KeycloakFixture.TestUsername);
+    }
+
+    [Fact]
+    public async Task SignupAsync_WithNewUser_CreatesUser()
+    {
+        var username = $"newuser-{Guid.NewGuid():N}";
+        var request  = new SignupRequestDto(username, "NewUser@123");
+
+        var result = await User.SignupAsync(request);
+
+        Assert.True(result.IsSuccessful);
+
+        // Verify the user was actually created
+        var found = await User.GetUserByUsernameAsync(username);
+        Assert.True(found.IsSuccessful);
+        Assert.Single(found.Response);
+    }
+
+    [Fact]
+    public async Task EnableDisableUserAsync_TogglesUserStatus()
+    {
+        // Disable
+        await User.DisableUserAsync(fixture.TestUserId);
+        var disabled = await User.GetUserAsync(fixture.TestUserId);
+        Assert.False(disabled.Response.Enabled);
+
+        // Re-enable
+        await User.EnableUserAsync(fixture.TestUserId);
+        var enabled = await User.GetUserAsync(fixture.TestUserId);
+        Assert.True(enabled.Response.Enabled);
+    }
+
+    [Fact]
+    public async Task SetUserPasswordAsync_ChangesPassword()
+    {
+        const string newPassword = "Updated@5678";
+        await User.SetUserPasswordAsync(fixture.TestUserId, newPassword);
+
+        // Verify new password works
+        var result = await User.SigninAsync(KeycloakFixture.TestUsername, newPassword);
+        Assert.True(result.IsSuccessful);
+
+        // Restore original password so other tests aren't affected
+        await User.SetUserPasswordAsync(fixture.TestUserId, KeycloakFixture.TestPassword);
+    }
+}
+
+[Collection(nameof(KeycloakCollection))]
+public class TokenManagementIntegrationTests(KeycloakFixture fixture)
+{
+    private IUserManagement  User  => fixture.Services.CreateScope().ServiceProvider.GetRequiredService<IUserManagement>();
+    private ITokenManagement Token => fixture.Services.CreateScope().ServiceProvider.GetRequiredService<ITokenManagement>();
+
+    [Fact]
+    public async Task RefreshTokenAsync_WithValidRefreshToken_ReturnsNewAccessToken()
+    {
+        var signin = await User.SigninAsync(KeycloakFixture.TestUsername, KeycloakFixture.TestPassword);
+        Assert.True(signin.IsSuccessful);
+
+        var result = await Token.RefreshTokenAsync(signin.Response.RefreshToken);
+
+        Assert.True(result.IsSuccessful);
+        Assert.NotEmpty(result.Response.AccessToken!);
+    }
+
+    [Fact]
+    public async Task RevokeTokenAsync_WithValidRefreshToken_RevokesSuccessfully()
+    {
+        var signin = await User.SigninAsync(KeycloakFixture.TestUsername, KeycloakFixture.TestPassword);
+        Assert.True(signin.IsSuccessful);
+
+        var result = await Token.RevokeTokenAsync(signin.Response.RefreshToken);
+
+        Assert.True(result.IsSuccessful);
+
+        // After revocation, the refresh token must no longer work
+        var refresh = await Token.RefreshTokenAsync(signin.Response.RefreshToken);
+        Assert.False(refresh.IsSuccessful);
+    }
+}
+
+[Collection(nameof(KeycloakCollection))]
+public class RoleManagementIntegrationTests(KeycloakFixture fixture)
+{
+    private IRoleManagement Role => fixture.Services.CreateScope().ServiceProvider.GetRequiredService<IRoleManagement>();
+
+    [Fact]
+    public async Task GetClientRoles_ReturnsCreatedTestRole()
+    {
+        var result = await Role.GetClientRoles();
+
+        Assert.True(result.IsSuccessful);
+        Assert.Contains(result.Response, r => r.Name == KeycloakFixture.TestRoleName);
+    }
+
+    [Fact]
+    public async Task AssignAndRemoveClientRoleToUser_WorksRoundTrip()
+    {
+        // Assign
+        var assign = await Role.AssignClientRoleToUser(
+            fixture.TestUserId, fixture.TestRoleId, KeycloakFixture.TestRoleName);
+        Assert.True(assign.IsSuccessful);
+
+        // Remove
+        var remove = await Role.RemoveClientRoleFromUserAsync(
+            fixture.TestUserId, fixture.TestRoleId, KeycloakFixture.TestRoleName);
+        Assert.True(remove.IsSuccessful);
+    }
+}
+
+[Collection(nameof(KeycloakCollection))]
+public class ClientManagementIntegrationTests(KeycloakFixture fixture)
+{
+    private IClientManagement Client => fixture.Services.CreateScope().ServiceProvider.GetRequiredService<IClientManagement>();
+
+    [Fact]
+    public async Task GetClientsAsync_ReturnsSdkClient()
+    {
+        var result = await Client.GetClientsAsync();
+
+        Assert.True(result.IsSuccessful);
+        Assert.Contains(result.Response, c => c.ClientId == KeycloakFixture.SdkClientId);
+    }
+
+    [Fact]
+    public async Task GetClientScopes_ReturnsScopes()
+    {
+        var result = await Client.GetClientScopes();
+
+        Assert.True(result.IsSuccessful);
+        Assert.NotEmpty(result.Response);
+    }
+
+    [Fact]
+    public async Task CreateAndDeleteClientAsync_WorksRoundTrip()
+    {
+        var newClientId = $"temp-client-{Guid.NewGuid():N}";
+        var createRequest = new CreateClientRequestDto
+        {
+            ClientId = newClientId,
+            Name     = "Temp Integration Test Client",
+            Enabled  = true
+        };
+
+        // Create
+        var created = await Client.CreateClientAsync(createRequest);
+        Assert.True(created.IsSuccessful);
+
+        // Find the UUID
+        var clients = await Client.GetClientsAsync();
+        var found   = clients.Response.FirstOrDefault(c => c.ClientId == newClientId);
+        Assert.NotNull(found);
+
+        // Delete
+        var deleted = await Client.DeleteClientAsync(found.Id);
+        Assert.True(deleted.IsSuccessful);
+    }
+}

--- a/Keycloak.Net.Sdk.UnitTests/ClientManagementTests.cs
+++ b/Keycloak.Net.Sdk.UnitTests/ClientManagementTests.cs
@@ -1,0 +1,109 @@
+using System.Net;
+using Keycloak.Net.Sdk.Clients;
+using Keycloak.Net.Sdk.Clients.Contracts;
+using Keycloak.Net.Sdk.Configurations;
+using Keycloak.Net.Sdk.UnitTests.Helpers;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Keycloak.Net.Sdk.UnitTests;
+
+public class ClientManagementTests
+{
+    private readonly IOptions<KeycloakConfiguration> _options = Options.Create(new KeycloakConfiguration
+    {
+        ServerUrl    = "http://localhost:8080/",
+        RealmName    = TestData.RealmName,
+        ClientId     = TestData.ClientId,
+        ClientSecret = TestData.ClientSecret,
+        ClientUuid   = TestData.ClientUuid
+    });
+
+    private (ClientManagement Sut, FakeHttpMessageHandler Handler) CreateSut()
+    {
+        var (factory, handler) = HttpClientFactoryHelper.Create();
+        return (new ClientManagement(factory, _options), handler);
+    }
+
+    // ── GetClientScopes ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetClientScopes_Success_ReturnsScopeList()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.ClientScopesResponse);
+
+        var result = await sut.GetClientScopes();
+
+        Assert.True(result.IsSuccessful);
+        Assert.Single(result.Response);
+        Assert.Equal("profile", result.Response[0].Name);
+        Assert.Contains($"realms/{TestData.RealmName}/client-scopes", handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    // ── GetClientsAsync ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetClientsAsync_Success_ReturnsClientList()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.ClientsResponse);
+
+        var result = await sut.GetClientsAsync();
+
+        Assert.True(result.IsSuccessful);
+        Assert.Single(result.Response);
+        Assert.Equal("test-client", result.Response[0].ClientId);
+        Assert.Equal("client-abc", result.Response[0].Id);
+        Assert.True(result.Response[0].ServiceAccountsEnabled);
+    }
+
+    // ── CreateClientAsync ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateClientAsync_Success_SendsCorrectRequest()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.Created);
+
+        var request = new CreateClientRequestDto { ClientId = "new-client", Name = "New Client" };
+        var result = await sut.CreateClientAsync(request);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Post, handler.SentRequests[0].Method);
+        Assert.Contains($"admin/realms/{TestData.RealmName}/clients", handler.SentRequests[0].RequestUri!.ToString());
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("new-client", body);
+    }
+
+    // ── DeleteClientAsync ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteClientAsync_Success_SendsDeleteRequest()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.DeleteClientAsync(TestData.ClientUuid);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Delete, handler.SentRequests[0].Method);
+        Assert.Contains(TestData.ClientUuid, handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    // ── EnableServiceAccountAsync ─────────────────────────────────────────────
+
+    [Fact]
+    public async Task EnableServiceAccountAsync_Success_SendsPutWithServiceAccountsEnabled()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.EnableServiceAccountAsync(TestData.ClientUuid);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Put, handler.SentRequests[0].Method);
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"serviceAccountsEnabled\":true", body);
+    }
+}

--- a/Keycloak.Net.Sdk.UnitTests/Helpers/FakeHttpMessageHandler.cs
+++ b/Keycloak.Net.Sdk.UnitTests/Helpers/FakeHttpMessageHandler.cs
@@ -1,0 +1,26 @@
+using System.Net;
+using System.Text;
+
+namespace Keycloak.Net.Sdk.UnitTests.Helpers;
+
+public class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly Queue<HttpResponseMessage> _responses = new();
+    public List<HttpRequestMessage> SentRequests { get; } = [];
+
+    public void AddResponse(HttpStatusCode statusCode, string? jsonContent = null)
+    {
+        var message = new HttpResponseMessage(statusCode);
+        if (jsonContent != null)
+            message.Content = new StringContent(jsonContent, Encoding.UTF8, "application/json");
+        _responses.Enqueue(message);
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        SentRequests.Add(request);
+        if (!_responses.TryDequeue(out var response))
+            throw new InvalidOperationException("No more responses configured for this test.");
+        return Task.FromResult(response);
+    }
+}

--- a/Keycloak.Net.Sdk.UnitTests/Helpers/HttpClientFactoryHelper.cs
+++ b/Keycloak.Net.Sdk.UnitTests/Helpers/HttpClientFactoryHelper.cs
@@ -1,0 +1,18 @@
+using Moq;
+
+namespace Keycloak.Net.Sdk.UnitTests.Helpers;
+
+public static class HttpClientFactoryHelper
+{
+    public static (IHttpClientFactory Factory, FakeHttpMessageHandler Handler) Create(
+        string baseAddress = "http://localhost:8080/")
+    {
+        var handler = new FakeHttpMessageHandler();
+        var httpClient = new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
+
+        var factory = new Mock<IHttpClientFactory>();
+        factory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(httpClient);
+
+        return (factory.Object, handler);
+    }
+}

--- a/Keycloak.Net.Sdk.UnitTests/Helpers/TestData.cs
+++ b/Keycloak.Net.Sdk.UnitTests/Helpers/TestData.cs
@@ -1,0 +1,80 @@
+namespace Keycloak.Net.Sdk.UnitTests.Helpers;
+
+public static class TestData
+{
+    public const string RealmName    = "test-realm";
+    public const string ClientId     = "test-client";
+    public const string ClientSecret = "test-secret";
+    public const string ClientUuid   = "client-uuid-123";
+    public const string UserId       = "user-id-abc123";
+    public const string Username     = "testuser";
+    public const string Password     = "password123";
+    public const string RoleId       = "role-id-xyz";
+    public const string RoleName     = "test-role";
+    public const string AccessToken  = "eyJhbGciOiJSUzI1NiJ9.test.token";
+    public const string RefreshToken = "eyJhbGciOiJIUzUxMiJ9.refresh.token";
+
+    public static string SigninResponse => $$"""
+        {
+            "access_token": "{{AccessToken}}",
+            "expires_in": 300,
+            "refresh_expires_in": 1800,
+            "refresh_token": "{{RefreshToken}}",
+            "token_type": "Bearer",
+            "not-before-policy": 0,
+            "session_state": "sess-123",
+            "scope": "profile email"
+        }
+        """;
+
+    public static string UserInfoResponse => $$"""
+        {
+            "id": "{{UserId}}",
+            "username": "{{Username}}",
+            "emailVerified": false,
+            "createdTimestamp": 1700000000000,
+            "enabled": true,
+            "totp": false,
+            "notBefore": 0
+        }
+        """;
+
+    public static string UserListResponse => $"[{UserInfoResponse}]";
+
+    public static string ClientRolesResponse => $$"""
+        [
+            {
+                "id": "{{RoleId}}",
+                "name": "{{RoleName}}",
+                "description": "Test role",
+                "composite": false,
+                "clientRole": true,
+                "containerId": "{{ClientUuid}}"
+            }
+        ]
+        """;
+
+    public static string ClientScopesResponse => """
+        [
+            {
+                "id": "scope-id-1",
+                "name": "profile",
+                "description": "OpenID Connect built-in scope: profile",
+                "protocol": "openid-connect"
+            }
+        ]
+        """;
+
+    public static string ClientsResponse => """
+        [
+            {
+                "id": "client-abc",
+                "clientId": "test-client",
+                "name": "Test Client",
+                "enabled": true,
+                "publicClient": false,
+                "serviceAccountsEnabled": true
+            }
+        ]
+        """;
+}

--- a/Keycloak.Net.Sdk.UnitTests/Keycloak.Net.Sdk.UnitTests.csproj
+++ b/Keycloak.Net.Sdk.UnitTests/Keycloak.Net.Sdk.UnitTests.csproj
@@ -1,0 +1,24 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <IsPackable>false</IsPackable>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+        <PackageReference Include="xunit" Version="2.9.2" />
+        <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+            <PrivateAssets>all</PrivateAssets>
+        </PackageReference>
+        <PackageReference Include="Moq" Version="4.20.72" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\Keycloak.Net.Sdk\Keycloak.Net.Sdk.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Keycloak.Net.Sdk.UnitTests/RealmManagementTests.cs
+++ b/Keycloak.Net.Sdk.UnitTests/RealmManagementTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using Keycloak.Net.Sdk.Configurations;
+using Keycloak.Net.Sdk.Contracts;
+using Keycloak.Net.Sdk.Realms;
+using Keycloak.Net.Sdk.UnitTests.Helpers;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Keycloak.Net.Sdk.UnitTests;
+
+public class RealmManagementTests
+{
+    private readonly IOptions<KeycloakConfiguration> _options = Options.Create(new KeycloakConfiguration
+    {
+        ServerUrl      = "http://localhost:8080/",
+        RealmName      = TestData.RealmName,
+        ClientId       = TestData.ClientId,
+        ClientSecret   = TestData.ClientSecret,
+        ClientUuid     = TestData.ClientUuid,
+        AdminUsername  = "admin",
+        AdminPassword  = "admin-password"
+    });
+
+    private (RealmManagement Sut, FakeHttpMessageHandler Handler) CreateSut()
+    {
+        var (factory, handler) = HttpClientFactoryHelper.Create();
+        return (new RealmManagement(factory, _options), handler);
+    }
+
+    [Fact]
+    public async Task CreateRealmAsync_Success_FirstGetsAdminTokenThenCreatesRealm()
+    {
+        var (sut, handler) = CreateSut();
+        // First call: admin token; second call: realm creation
+        handler.AddResponse(HttpStatusCode.OK, TestData.SigninResponse);
+        handler.AddResponse(HttpStatusCode.Created);
+
+        var result = await sut.CreateRealmAsync("new-realm");
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(2, handler.SentRequests.Count);
+        // First request must be the token endpoint
+        Assert.Contains("openid-connect/token", handler.SentRequests[0].RequestUri!.ToString());
+        // Second request must be the realm creation
+        Assert.Contains("admin/realms", handler.SentRequests[1].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Post, handler.SentRequests[1].Method);
+        var body = await handler.SentRequests[1].Content!.ReadAsStringAsync();
+        Assert.Contains("new-realm", body);
+    }
+
+    [Fact]
+    public async Task CreateRealmAsync_AdminTokenFails_ThrowsKeycloakException()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.Unauthorized);
+
+        await Assert.ThrowsAsync<KeycloakException>(() => sut.CreateRealmAsync("new-realm"));
+    }
+}

--- a/Keycloak.Net.Sdk.UnitTests/RoleManagementTests.cs
+++ b/Keycloak.Net.Sdk.UnitTests/RoleManagementTests.cs
@@ -1,0 +1,91 @@
+using System.Net;
+using Keycloak.Net.Sdk.Configurations;
+using Keycloak.Net.Sdk.Roles;
+using Keycloak.Net.Sdk.UnitTests.Helpers;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Keycloak.Net.Sdk.UnitTests;
+
+public class RoleManagementTests
+{
+    private readonly IOptions<KeycloakConfiguration> _options = Options.Create(new KeycloakConfiguration
+    {
+        ServerUrl    = "http://localhost:8080/",
+        RealmName    = TestData.RealmName,
+        ClientId     = TestData.ClientId,
+        ClientSecret = TestData.ClientSecret,
+        ClientUuid   = TestData.ClientUuid
+    });
+
+    private (RoleManagement Sut, FakeHttpMessageHandler Handler) CreateSut()
+    {
+        var (factory, handler) = HttpClientFactoryHelper.Create();
+        return (new RoleManagement(factory, _options), handler);
+    }
+
+    // ── GetClientRoles ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetClientRoles_Success_ReturnsRoleList()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.ClientRolesResponse);
+
+        var result = await sut.GetClientRoles();
+
+        Assert.True(result.IsSuccessful);
+        Assert.Single(result.Response);
+        Assert.Equal(TestData.RoleId, result.Response[0].Id);
+        Assert.Equal(TestData.RoleName, result.Response[0].Name);
+        Assert.True(result.Response[0].ClientRole);
+        Assert.Contains($"clients/{TestData.ClientUuid}/roles", handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task GetClientRoles_Failure_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.Unauthorized);
+
+        var result = await sut.GetClientRoles();
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+    }
+
+    // ── AssignClientRoleToUser ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AssignClientRoleToUser_Success_SendsCorrectRequest()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.AssignClientRoleToUser(TestData.UserId, TestData.RoleId, TestData.RoleName);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Contains($"users/{TestData.UserId}/role-mappings/clients/{TestData.ClientUuid}",
+            handler.SentRequests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Post, handler.SentRequests[0].Method);
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains(TestData.RoleId, body);
+        Assert.Contains(TestData.RoleName, body);
+    }
+
+    // ── RemoveClientRoleFromUserAsync ─────────────────────────────────────────
+
+    [Fact]
+    public async Task RemoveClientRoleFromUserAsync_Success_SendsDeleteRequest()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.RemoveClientRoleFromUserAsync(TestData.UserId, TestData.RoleId, TestData.RoleName);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Contains($"users/{TestData.UserId}/role-mappings/clients/{TestData.ClientUuid}",
+            handler.SentRequests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Delete, handler.SentRequests[0].Method);
+    }
+}

--- a/Keycloak.Net.Sdk.UnitTests/TokenManagementTests.cs
+++ b/Keycloak.Net.Sdk.UnitTests/TokenManagementTests.cs
@@ -1,0 +1,85 @@
+using System.Net;
+using Keycloak.Net.Sdk.Athentications;
+using Keycloak.Net.Sdk.Configurations;
+using Keycloak.Net.Sdk.UnitTests.Helpers;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Keycloak.Net.Sdk.UnitTests;
+
+public class TokenManagementTests
+{
+    private readonly IOptions<KeycloakConfiguration> _options = Options.Create(new KeycloakConfiguration
+    {
+        ServerUrl    = "http://localhost:8080/",
+        RealmName    = TestData.RealmName,
+        ClientId     = TestData.ClientId,
+        ClientSecret = TestData.ClientSecret,
+        ClientUuid   = TestData.ClientUuid
+    });
+
+    private (TokenManagement Sut, FakeHttpMessageHandler Handler) CreateSut()
+    {
+        var (factory, handler) = HttpClientFactoryHelper.Create();
+        return (new TokenManagement(factory, _options), handler);
+    }
+
+    // ── RefreshTokenAsync ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RefreshTokenAsync_Success_ReturnsNewTokens()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.SigninResponse);
+
+        var result = await sut.RefreshTokenAsync(TestData.RefreshToken);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(TestData.AccessToken, result.Response.AccessToken);
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("grant_type=refresh_token", body);
+        Assert.Contains($"refresh_token={TestData.RefreshToken}", body);
+    }
+
+    [Fact]
+    public async Task RefreshTokenAsync_ExpiredRefreshToken_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.BadRequest);
+
+        var result = await sut.RefreshTokenAsync("expired-refresh-token");
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+    }
+
+    // ── RevokeTokenAsync ──────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RevokeTokenAsync_Success_ReturnsSuccessResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK);
+
+        var result = await sut.RevokeTokenAsync(TestData.RefreshToken);
+
+        Assert.True(result.IsSuccessful);
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains($"token={TestData.RefreshToken}", body);
+        Assert.Contains("token_type_hint=refresh_token", body);
+        Assert.Contains($"realms/{TestData.RealmName}/protocol/openid-connect/revoke",
+            handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task RevokeTokenAsync_Failure_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.BadRequest);
+
+        var result = await sut.RevokeTokenAsync("invalid-token");
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.BadRequest, result.StatusCode);
+    }
+}

--- a/Keycloak.Net.Sdk.UnitTests/TokenProviderTests.cs
+++ b/Keycloak.Net.Sdk.UnitTests/TokenProviderTests.cs
@@ -44,7 +44,7 @@ public class TokenProviderTests
         var second = await sut.GetTokenAsync();
 
         Assert.Equal(first, second);
-        // Only one HTTP call — second call hits the cache
+        // Only one HTTP call  second call hits the cache
         Assert.Single(handler.SentRequests);
     }
 
@@ -52,7 +52,7 @@ public class TokenProviderTests
     public async Task GetTokenAsync_ConcurrentCalls_FetchesTokenOnlyOnce()
     {
         var (factory, handler) = HttpClientFactoryHelper.Create();
-        // Add one response — if two requests are made concurrently, the second will throw
+        // Add one response  if two requests are made concurrently, the second will throw
         handler.AddResponse(HttpStatusCode.OK, TestData.SigninResponse);
         var sut = new TokenProvider(factory, _options);
 

--- a/Keycloak.Net.Sdk.UnitTests/TokenProviderTests.cs
+++ b/Keycloak.Net.Sdk.UnitTests/TokenProviderTests.cs
@@ -1,0 +1,65 @@
+using System.Net;
+using Keycloak.Net.Sdk.Athentications;
+using Keycloak.Net.Sdk.Configurations;
+using Keycloak.Net.Sdk.UnitTests.Helpers;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Keycloak.Net.Sdk.UnitTests;
+
+public class TokenProviderTests
+{
+    private readonly IOptions<KeycloakConfiguration> _options = Options.Create(new KeycloakConfiguration
+    {
+        ServerUrl    = "http://localhost:8080/",
+        RealmName    = TestData.RealmName,
+        ClientId     = TestData.ClientId,
+        ClientSecret = TestData.ClientSecret,
+        ClientUuid   = TestData.ClientUuid
+    });
+
+    [Fact]
+    public async Task GetTokenAsync_FirstCall_FetchesTokenFromKeycloak()
+    {
+        var (factory, handler) = HttpClientFactoryHelper.Create();
+        handler.AddResponse(HttpStatusCode.OK, TestData.SigninResponse);
+        var sut = new TokenProvider(factory, _options);
+
+        var token = await sut.GetTokenAsync();
+
+        Assert.Equal(TestData.AccessToken, token);
+        Assert.Single(handler.SentRequests);
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("grant_type=client_credentials", body);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_SecondCallWithinExpiry_ReturnsCachedToken()
+    {
+        var (factory, handler) = HttpClientFactoryHelper.Create();
+        handler.AddResponse(HttpStatusCode.OK, TestData.SigninResponse);
+        var sut = new TokenProvider(factory, _options);
+
+        var first  = await sut.GetTokenAsync();
+        var second = await sut.GetTokenAsync();
+
+        Assert.Equal(first, second);
+        // Only one HTTP call — second call hits the cache
+        Assert.Single(handler.SentRequests);
+    }
+
+    [Fact]
+    public async Task GetTokenAsync_ConcurrentCalls_FetchesTokenOnlyOnce()
+    {
+        var (factory, handler) = HttpClientFactoryHelper.Create();
+        // Add one response — if two requests are made concurrently, the second will throw
+        handler.AddResponse(HttpStatusCode.OK, TestData.SigninResponse);
+        var sut = new TokenProvider(factory, _options);
+
+        var tasks = Enumerable.Range(0, 5).Select(_ => sut.GetTokenAsync());
+        var results = await Task.WhenAll(tasks);
+
+        Assert.All(results, t => Assert.Equal(TestData.AccessToken, t));
+        Assert.Single(handler.SentRequests);
+    }
+}

--- a/Keycloak.Net.Sdk.UnitTests/UserManagementTests.cs
+++ b/Keycloak.Net.Sdk.UnitTests/UserManagementTests.cs
@@ -1,0 +1,202 @@
+using System.Net;
+using Keycloak.Net.Sdk.Configurations;
+using Keycloak.Net.Sdk.Users;
+using Keycloak.Net.Sdk.Users.Contracts;
+using Keycloak.Net.Sdk.UnitTests.Helpers;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Keycloak.Net.Sdk.UnitTests;
+
+public class UserManagementTests
+{
+    private readonly IOptions<KeycloakConfiguration> _options = Options.Create(new KeycloakConfiguration
+    {
+        ServerUrl    = "http://localhost:8080/",
+        RealmName    = TestData.RealmName,
+        ClientId     = TestData.ClientId,
+        ClientSecret = TestData.ClientSecret,
+        ClientUuid   = TestData.ClientUuid
+    });
+
+    private (UserManagement Sut, FakeHttpMessageHandler Handler) CreateSut()
+    {
+        var (factory, handler) = HttpClientFactoryHelper.Create();
+        return (new UserManagement(factory, _options), handler);
+    }
+
+    // ── SignupAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SignupAsync_Success_ReturnsSuccessResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.Created);
+
+        var result = await sut.SignupAsync(new SignupRequestDto(TestData.Username, TestData.Password));
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.Created, result.StatusCode);
+        Assert.Contains($"admin/realms/{TestData.RealmName}/users", handler.SentRequests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Post, handler.SentRequests[0].Method);
+    }
+
+    [Fact]
+    public async Task SignupAsync_UserAlreadyExists_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.Conflict);
+
+        var result = await sut.SignupAsync(new SignupRequestDto(TestData.Username, TestData.Password));
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.Conflict, result.StatusCode);
+    }
+
+    // ── SigninAsync ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SigninAsync_Success_ReturnsTokens()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.SigninResponse);
+
+        var result = await sut.SigninAsync(TestData.Username, TestData.Password);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(TestData.AccessToken, result.Response.AccessToken);
+        Assert.Equal(TestData.RefreshToken, result.Response.RefreshToken);
+        Assert.Equal(300, result.Response.ExpiresIn);
+        Assert.Contains($"realms/{TestData.RealmName}/protocol/openid-connect/token",
+            handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task SigninAsync_InvalidCredentials_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.Unauthorized);
+
+        var result = await sut.SigninAsync(TestData.Username, "wrong-password");
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+    }
+
+    [Fact]
+    public async Task SigninAsync_DoesNotMutateSharedDefaultRequestHeaders()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.SigninResponse);
+
+        await sut.SigninAsync(TestData.Username, TestData.Password);
+
+        // Authorization must be set per-request, not on shared DefaultRequestHeaders
+        var authHeader = handler.SentRequests[0].Headers.Authorization;
+        Assert.Null(authHeader);
+    }
+
+    // ── GetUserAsync ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetUserAsync_Success_ReturnsUserInfo()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.UserInfoResponse);
+
+        var result = await sut.GetUserAsync(TestData.UserId);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(TestData.UserId, result.Response.Id);
+        Assert.Equal(TestData.Username, result.Response.Username);
+        Assert.True(result.Response.Enabled);
+        Assert.Contains($"users/{TestData.UserId}", handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task GetUserAsync_NotFound_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NotFound);
+
+        var result = await sut.GetUserAsync("nonexistent-id");
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+    }
+
+    // ── GetUserByUsernameAsync ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetUserByUsernameAsync_Success_ReturnsUserList()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.UserListResponse);
+
+        var result = await sut.GetUserByUsernameAsync(TestData.Username);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Single(result.Response);
+        Assert.Equal(TestData.UserId, result.Response[0].Id);
+        Assert.Contains($"username={TestData.Username}", handler.SentRequests[0].RequestUri!.Query);
+    }
+
+    // ── SetUserPasswordAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task SetUserPasswordAsync_Success_SendsCorrectRequest()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        await sut.SetUserPasswordAsync(TestData.UserId, "newPassword!");
+
+        Assert.Contains($"users/{TestData.UserId}/reset-password", handler.SentRequests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Put, handler.SentRequests[0].Method);
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"type\":\"password\"", body);
+        Assert.Contains("\"value\":\"newPassword!\"", body);
+    }
+
+    // ── DeleteUserAsync ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteUserAsync_Success_SendsDeleteRequest()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        await sut.DeleteUserAsync(TestData.UserId);
+
+        Assert.Contains($"users/{TestData.UserId}", handler.SentRequests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Delete, handler.SentRequests[0].Method);
+    }
+
+    // ── EnableUserAsync / DisableUserAsync ────────────────────────────────────
+
+    [Fact]
+    public async Task EnableUserAsync_Success_SendsEnabledTrue()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        await sut.EnableUserAsync(TestData.UserId);
+
+        Assert.Equal(HttpMethod.Put, handler.SentRequests[0].Method);
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"enabled\":true", body);
+    }
+
+    [Fact]
+    public async Task DisableUserAsync_Success_SendsEnabledFalse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        await sut.DisableUserAsync(TestData.UserId);
+
+        Assert.Equal(HttpMethod.Put, handler.SentRequests[0].Method);
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains("\"enabled\":false", body);
+    }
+}

--- a/Keycloak.Net.Sdk/Athentications/TokenManagement.cs
+++ b/Keycloak.Net.Sdk/Athentications/TokenManagement.cs
@@ -9,7 +9,7 @@ namespace Keycloak.Net.Sdk.Athentications;
 public class TokenManagement(IHttpClientFactory httpClientFactory, IOptions<KeycloakConfiguration> keyCloakConfiguration)
     : ITokenManagement
 {
-    private readonly HttpClient _httpClient = httpClientFactory.CreateClient("keycloak");
+    private readonly HttpClient _httpClient = httpClientFactory.CreateClient("keycloak-token");
     public async Task<KeycloakBaseResponse<SigninResponseDto>> RefreshTokenAsync(string refreshToken, CancellationToken cancellationToken = default)
     {
         var uri = new Uri($"realms/{keyCloakConfiguration.Value.RealmName}/protocol/openid-connect/token", UriKind.Relative);

--- a/Keycloak.Net.Sdk/Athentications/TokenProvider.cs
+++ b/Keycloak.Net.Sdk/Athentications/TokenProvider.cs
@@ -8,19 +8,16 @@ namespace Keycloak.Net.Sdk.Athentications;
 
 public sealed class TokenProvider : ITokenProvider
 {
-    private readonly HttpClient _httpClient;
+    private readonly IHttpClientFactory _httpClientFactory;
     private readonly SemaphoreSlim _semaphore = new(1, 1);
     private string? _token;
     private DateTime _expiresAt;
     private readonly IOptions<KeycloakConfiguration> _keycloakConfiguration;
 
-    public TokenProvider(IOptions<KeycloakConfiguration> keycloakConfiguration)
+    public TokenProvider(IHttpClientFactory httpClientFactory, IOptions<KeycloakConfiguration> keycloakConfiguration)
     {
+        _httpClientFactory = httpClientFactory;
         _keycloakConfiguration = keycloakConfiguration;
-        _httpClient = new HttpClient()
-        {
-            BaseAddress = new Uri(keycloakConfiguration.Value.ServerUrl)
-        };
     }
 
     public async Task<string> GetTokenAsync()
@@ -38,7 +35,7 @@ public sealed class TokenProvider : ITokenProvider
             var response = await GetAdminTokenAsync();
 
             _token = response.Response.AccessToken;
-            _expiresAt = DateTime.UtcNow.AddSeconds(response.Response.ExpiresIn - 30); // make sure that token will be got before it be expired
+            _expiresAt = DateTime.UtcNow.AddSeconds(response.Response.ExpiresIn - 30);
 
             return _token!;
         }
@@ -50,6 +47,7 @@ public sealed class TokenProvider : ITokenProvider
 
     private async Task<KeycloakBaseResponse<SigninResponseDto>> GetAdminTokenAsync()
     {
+        var httpClient = _httpClientFactory.CreateClient("keycloak-token");
         var uri = $"realms/{_keycloakConfiguration.Value.RealmName}/protocol/openid-connect/token";
 
         var requestData = new Dictionary<string, string>
@@ -60,8 +58,7 @@ public sealed class TokenProvider : ITokenProvider
         };
 
         var requestContent = new FormUrlEncodedContent(requestData);
-
-        var response = await _httpClient.PostAsync(uri, requestContent);
+        var response = await httpClient.PostAsync(uri, requestContent);
 
         return await response.HandleResponseAsync<SigninResponseDto>();
     }

--- a/Keycloak.Net.Sdk/Clients/ClientManagement.cs
+++ b/Keycloak.Net.Sdk/Clients/ClientManagement.cs
@@ -13,12 +13,12 @@ public class ClientManagement(IHttpClientFactory httpClientFactory, IOptions<Key
 {
     private readonly HttpClient _httpClient = httpClientFactory.CreateClient("keycloak");
 
-    public async Task<KeycloakBaseResponse<List<ClientScopeResponseDto>>> GetClientScopes()
+    public async Task<KeycloakBaseResponse<List<ClientScopeResponseDto>>> GetClientScopes(CancellationToken cancellationToken = default)
     {
         var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/client-scopes";
         var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
 
-        var response = await _httpClient.SendAsync(request);
+        var response = await _httpClient.SendAsync(request, cancellationToken);
         return await response.HandleResponseAsync<List<ClientScopeResponseDto>>();
     }
     

--- a/Keycloak.Net.Sdk/Clients/ClientManagement.cs
+++ b/Keycloak.Net.Sdk/Clients/ClientManagement.cs
@@ -58,13 +58,13 @@ public class ClientManagement(IHttpClientFactory httpClientFactory, IOptions<Key
 
         var requestUrl = new Uri($"admin/realms/{keyCloakConfiguration.Value.RealmName}/clients/{clientId}", UriKind.Relative);
         
-        var request = new HttpRequestMessage(HttpMethod.Post, requestUrl)
+        var request = new HttpRequestMessage(HttpMethod.Put, requestUrl)
         {
             Content = new StringContent(JsonSerializer.Serialize(requestDto), Encoding.UTF8, "application/json")
         };
-        
+
         var response = await _httpClient.SendAsync(request, cancellationToken);
-        
+
         return await response.HandleResponseAsync();
     }
 

--- a/Keycloak.Net.Sdk/Clients/Contracts/ClientResponseDto.cs
+++ b/Keycloak.Net.Sdk/Clients/Contracts/ClientResponseDto.cs
@@ -1,11 +1,19 @@
+using System.Text.Json.Serialization;
+
 namespace Keycloak.Net.Sdk.Clients.Contracts;
 
 public sealed record ClientResponseDto()
 {
+    [JsonPropertyName("id")]
     public string Id { get; set; }
+    [JsonPropertyName("clientId")]
     public string ClientId { get; set; }
+    [JsonPropertyName("name")]
     public string Name { get; set; }
+    [JsonPropertyName("enabled")]
     public bool? Enabled { get; set; }
+    [JsonPropertyName("publicClient")]
     public bool? PublicClient { get; set; }
+    [JsonPropertyName("serviceAccountsEnabled")]
     public bool? ServiceAccountsEnabled { get; set; }
-};
+}

--- a/Keycloak.Net.Sdk/Clients/Contracts/CreateClientRequestDto.cs
+++ b/Keycloak.Net.Sdk/Clients/Contracts/CreateClientRequestDto.cs
@@ -1,12 +1,27 @@
+using System.Text.Json.Serialization;
+
 namespace Keycloak.Net.Sdk.Clients.Contracts;
 
 public record CreateClientRequestDto()
 {
+    [JsonPropertyName("clientId")]
     public string ClientId { get; set; }
+
+    [JsonPropertyName("name")]
     public string Name { get; set; }
+
+    [JsonPropertyName("enabled")]
     public bool Enabled { get; set; } = true;
+
+    [JsonPropertyName("publicClient")]
     public bool PublicClient { get; set; } = false;
+
+    [JsonPropertyName("serviceAccountsEnabled")]
     public bool ServiceAccountsEnabled { get; set; } = false;
+
+    [JsonPropertyName("protocol")]
     public string Protocol { get; set; } = "openid-connect";
+
+    [JsonPropertyName("redirectUris")]
     public List<string> RedirectUris { get; set; } = new();
-};
+}

--- a/Keycloak.Net.Sdk/Clients/Contracts/IClientManagement.cs
+++ b/Keycloak.Net.Sdk/Clients/Contracts/IClientManagement.cs
@@ -4,7 +4,7 @@ namespace Keycloak.Net.Sdk.Clients.Contracts;
 
 public interface IClientManagement
 {
-    Task<KeycloakBaseResponse<List<ClientScopeResponseDto>>> GetClientScopes();
+    Task<KeycloakBaseResponse<List<ClientScopeResponseDto>>> GetClientScopes(CancellationToken cancellationToken = default);
     Task<KeycloakBaseResponse<List<ClientResponseDto>>> GetClientsAsync(CancellationToken cancellationToken = default);
     Task<KeycloakBaseResponse> CreateClientAsync(CreateClientRequestDto requestDto, CancellationToken cancellationToken = default);
     Task<KeycloakBaseResponse> DeleteClientAsync(string clientId, CancellationToken cancellationToken = default);

--- a/Keycloak.Net.Sdk/Clients/Contracts/UpdateClientStatusRequestDto.cs
+++ b/Keycloak.Net.Sdk/Clients/Contracts/UpdateClientStatusRequestDto.cs
@@ -1,6 +1,9 @@
+using System.Text.Json.Serialization;
+
 namespace Keycloak.Net.Sdk.Clients.Contracts;
 
 public sealed record UpdateClientStatusRequestDto()
 {
+    [JsonPropertyName("serviceAccountsEnabled")]
     public bool ServiceAccountsEnabled { get; set; }
 }

--- a/Keycloak.Net.Sdk/Contracts/Responses/KeycloakBaseResponse.cs
+++ b/Keycloak.Net.Sdk/Contracts/Responses/KeycloakBaseResponse.cs
@@ -11,9 +11,6 @@ public record KeycloakBaseResponse<T>(
     where T : class, new()
 {
     public T Response { get; protected init; } = Response;
-    public bool IsSuccessful { get; protected init; } = IsSuccessful;
-    public HttpStatusCode StatusCode { get; protected init; } = StatusCode;
-    public string? ErrorMessage { get; protected init; } = ErrorMessage;
 }
 
 public record KeycloakBaseResponse(

--- a/Keycloak.Net.Sdk/Extensions/ExceptionHandler.cs
+++ b/Keycloak.Net.Sdk/Extensions/ExceptionHandler.cs
@@ -15,13 +15,13 @@ internal static class ExceptionHandler
 
         var deserializedResponse = JsonSerializer.Deserialize<T>(responseContent)!;
 
-        return new KeycloakSuccessResponse<T>(deserializedResponse);
+        return new KeycloakBaseResponse<T>(deserializedResponse, true, response.StatusCode);
     }
 
     public static async Task<KeycloakBaseResponse> HandleResponseAsync(this HttpResponseMessage response)
     {
         return !response.IsSuccessStatusCode
             ? new KeycloakFailureResponse(response.StatusCode, response.ReasonPhrase)
-            : new KeycloakSuccessResponse();
+            : new KeycloakBaseResponse(true, response.StatusCode);
     }
 }

--- a/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
+++ b/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
@@ -20,7 +20,8 @@ public static class ServiceRegistrations
     {
         // Bind options
         services.Configure<KeycloakConfiguration>(configuration.GetSection("keycloak"));
-        var options = configuration.GetSection("keycloak").Get<KeycloakConfiguration>();
+        var options = configuration.GetSection("keycloak").Get<KeycloakConfiguration>()
+            ?? throw new InvalidOperationException("Keycloak configuration section is missing. Add a 'keycloak' section to appsettings.json.");
 
         // Register TokenCache
         services.AddSingleton<ITokenProvider, TokenProvider>();

--- a/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
+++ b/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
@@ -34,11 +34,11 @@ public static class ServiceRegistrations
             .AddPolicyHandler(PollyExtensions.GetRetryPolicy(configuration))
             .AddHttpMessageHandler<KeycloakAuthHandler>();
 
-        // Register HttpClient for RealmManagement (no auth handler — uses master realm admin credentials)
+        // Register HttpClient for RealmManagement (no auth handler  uses master realm admin credentials)
         services.AddHttpClient("keycloak-admin", client => { client.BaseAddress = new Uri(options.ServerUrl); })
             .AddPolicyHandler(PollyExtensions.GetRetryPolicy(configuration));
 
-        // Register HttpClient for TokenProvider (no auth handler — used to fetch service-account tokens)
+        // Register HttpClient for TokenProvider (no auth handler  used to fetch service-account tokens)
         services.AddHttpClient("keycloak-token", client => { client.BaseAddress = new Uri(options.ServerUrl); })
             .AddPolicyHandler(PollyExtensions.GetRetryPolicy(configuration));
 

--- a/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
+++ b/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
@@ -33,6 +33,10 @@ public static class ServiceRegistrations
             .AddPolicyHandler(PollyExtensions.GetRetryPolicy(configuration))
             .AddHttpMessageHandler<KeycloakAuthHandler>();
 
+        // Register HttpClient for RealmManagement (no auth handler — uses master realm admin credentials)
+        services.AddHttpClient("keycloak-admin", client => { client.BaseAddress = new Uri(options.ServerUrl); })
+            .AddPolicyHandler(PollyExtensions.GetRetryPolicy(configuration));
+
         // Register managers
         services.AddScoped<IKeycloakManagement, KeycloakManagement>();
         services.AddScoped<IUserManagement, UserManagement>();

--- a/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
+++ b/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
@@ -37,6 +37,10 @@ public static class ServiceRegistrations
         services.AddHttpClient("keycloak-admin", client => { client.BaseAddress = new Uri(options.ServerUrl); })
             .AddPolicyHandler(PollyExtensions.GetRetryPolicy(configuration));
 
+        // Register HttpClient for TokenProvider (no auth handler — used to fetch service-account tokens)
+        services.AddHttpClient("keycloak-token", client => { client.BaseAddress = new Uri(options.ServerUrl); })
+            .AddPolicyHandler(PollyExtensions.GetRetryPolicy(configuration));
+
         // Register managers
         services.AddScoped<IKeycloakManagement, KeycloakManagement>();
         services.AddScoped<IUserManagement, UserManagement>();

--- a/Keycloak.Net.Sdk/Realms/IRealmManagement.cs
+++ b/Keycloak.Net.Sdk/Realms/IRealmManagement.cs
@@ -4,5 +4,5 @@ namespace Keycloak.Net.Sdk.Realms;
 
 public interface IRealmManagement
 {
-     Task<KeycloakBaseResponse> CreateRealmAsync(string realmName);
+    Task<KeycloakBaseResponse> CreateRealmAsync(string realmName, CancellationToken cancellationToken = default);
 }

--- a/Keycloak.Net.Sdk/Realms/RealmManagement.cs
+++ b/Keycloak.Net.Sdk/Realms/RealmManagement.cs
@@ -17,9 +17,9 @@ public sealed class RealmManagement(
 {
     private readonly HttpClient _httpClient = httpClientFactory.CreateClient("keycloak-admin");
 
-    public async Task<KeycloakBaseResponse> CreateRealmAsync(string realmName)
+    public async Task<KeycloakBaseResponse> CreateRealmAsync(string realmName, CancellationToken cancellationToken = default)
     {
-        var adminToken = await GetKeycloakAdminTokenAsync();
+        var adminToken = await GetKeycloakAdminTokenAsync(cancellationToken);
 
         if (!adminToken.IsSuccessful)
             throw new KeycloakException(keyCloakConfiguration.Value.ClientId, keyCloakConfiguration.Value.RealmName, "could not get keycloak's admin token");
@@ -36,12 +36,12 @@ public sealed class RealmManagement(
         };
         request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken.Response.AccessToken);
 
-        var response = await _httpClient.SendAsync(request);
+        var response = await _httpClient.SendAsync(request, cancellationToken);
 
         return await response.HandleResponseAsync();
     }
 
-    private async Task<KeycloakBaseResponse<SigninResponseDto>> GetKeycloakAdminTokenAsync()
+    private async Task<KeycloakBaseResponse<SigninResponseDto>> GetKeycloakAdminTokenAsync(CancellationToken cancellationToken = default)
     {
         var parameters = new Dictionary<string, string>
         {
@@ -51,7 +51,7 @@ public sealed class RealmManagement(
             { "password", keyCloakConfiguration.Value.AdminPassword }
         };
 
-        var response = await _httpClient.PostAsync("realms/master/protocol/openid-connect/token", new FormUrlEncodedContent(parameters));
+        var response = await _httpClient.PostAsync("realms/master/protocol/openid-connect/token", new FormUrlEncodedContent(parameters), cancellationToken);
 
         return await response.HandleResponseAsync<SigninResponseDto>();
     }

--- a/Keycloak.Net.Sdk/Realms/RealmManagement.cs
+++ b/Keycloak.Net.Sdk/Realms/RealmManagement.cs
@@ -8,19 +8,14 @@ using Keycloak.Net.Sdk.Contracts;
 using Keycloak.Net.Sdk.Contracts.Responses;
 using Keycloak.Net.Sdk.Extensions;
 using Microsoft.Extensions.Options;
-using Polly;
-using Polly.Retry;
 
 namespace Keycloak.Net.Sdk.Realms;
 
-public sealed class RealmManagement(IOptions<KeycloakConfiguration> keyCloakConfiguration) : IRealmManagement
+public sealed class RealmManagement(
+    IHttpClientFactory httpClientFactory,
+    IOptions<KeycloakConfiguration> keyCloakConfiguration) : IRealmManagement
 {
-    private readonly AsyncRetryPolicy<HttpResponseMessage> _retryPolicy = Policy
-        .Handle<HttpRequestException>()
-        .OrResult<HttpResponseMessage>(r => !r.IsSuccessStatusCode)
-        .WaitAndRetryAsync(
-            retryCount: keyCloakConfiguration.Value.NumberOfRetries, // Number of retries
-            sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(keyCloakConfiguration.Value.DelayBetweenRetryRequestsInSeconds));
+    private readonly HttpClient _httpClient = httpClientFactory.CreateClient("keycloak-admin");
 
     public async Task<KeycloakBaseResponse> CreateRealmAsync(string realmName)
     {
@@ -29,29 +24,25 @@ public sealed class RealmManagement(IOptions<KeycloakConfiguration> keyCloakConf
         if (!adminToken.IsSuccessful)
             throw new KeycloakException(keyCloakConfiguration.Value.ClientId, keyCloakConfiguration.Value.RealmName, "could not get keycloak's admin token");
 
-        using var client = new HttpClient();
-        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", adminToken.Response.AccessToken);
-
         var realmData = new
         {
             realm = realmName,
             enabled = true
         };
 
-        var json = JsonSerializer.Serialize(realmData);
-        var content = new StringContent(json, Encoding.UTF8, "application/json");
+        var request = new HttpRequestMessage(HttpMethod.Post, "admin/realms")
+        {
+            Content = new StringContent(JsonSerializer.Serialize(realmData), Encoding.UTF8, "application/json")
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", adminToken.Response.AccessToken);
 
-        var response = await _retryPolicy.ExecuteAsync(async () => await client.PostAsync($"{keyCloakConfiguration.Value.ServerUrl}/admin/realms", content));
+        var response = await _httpClient.SendAsync(request);
 
-        return !response.IsSuccessStatusCode
-            ? new KeycloakFailureResponse(response.StatusCode)
-            : new KeycloakBaseResponse(true, HttpStatusCode.OK);
+        return await response.HandleResponseAsync();
     }
 
     private async Task<KeycloakBaseResponse<SigninResponseDto>> GetKeycloakAdminTokenAsync()
     {
-        using var client = new HttpClient();
-
         var parameters = new Dictionary<string, string>
         {
             { "client_id", "admin-cli" },
@@ -60,7 +51,7 @@ public sealed class RealmManagement(IOptions<KeycloakConfiguration> keyCloakConf
             { "password", keyCloakConfiguration.Value.AdminPassword }
         };
 
-        var response = await client.PostAsync($"{keyCloakConfiguration.Value.ServerUrl}/realms/master/protocol/openid-connect/token", new FormUrlEncodedContent(parameters));
+        var response = await _httpClient.PostAsync("realms/master/protocol/openid-connect/token", new FormUrlEncodedContent(parameters));
 
         return await response.HandleResponseAsync<SigninResponseDto>();
     }

--- a/Keycloak.Net.Sdk/Roles/Contracts/IRoleManagement.cs
+++ b/Keycloak.Net.Sdk/Roles/Contracts/IRoleManagement.cs
@@ -4,7 +4,7 @@ namespace Keycloak.Net.Sdk.Roles.Contracts;
 
 public interface IRoleManagement
 {
-     Task<KeycloakBaseResponse<List<ClientRoleResponseDto>>> GetClientRoles();
-     Task<KeycloakBaseResponse> AssignClientRoleToUser(string userId, string roleId, string roleName);
-     Task<KeycloakBaseResponse> RemoveClientRoleFromUserAsync(string userId, string roleId, string roleName, CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse<List<ClientRoleResponseDto>>> GetClientRoles(CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse> AssignClientRoleToUser(string userId, string roleId, string roleName, CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse> RemoveClientRoleFromUserAsync(string userId, string roleId, string roleName, CancellationToken cancellationToken = default);
 }

--- a/Keycloak.Net.Sdk/Roles/RoleManagement.cs
+++ b/Keycloak.Net.Sdk/Roles/RoleManagement.cs
@@ -13,17 +13,17 @@ public sealed class RoleManagement(IHttpClientFactory httpClientFactory, IOption
 {
     private readonly HttpClient _httpClient = httpClientFactory.CreateClient("keycloak");
 
-    public async Task<KeycloakBaseResponse<List<ClientRoleResponseDto>>> GetClientRoles()
+    public async Task<KeycloakBaseResponse<List<ClientRoleResponseDto>>> GetClientRoles(CancellationToken cancellationToken = default)
     {
         var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/clients/{keyCloakConfiguration.Value.ClientUuid}/roles";
         var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
 
-        var response = await _httpClient.SendAsync(request);
+        var response = await _httpClient.SendAsync(request, cancellationToken);
 
         return await response.HandleResponseAsync<List<ClientRoleResponseDto>>();
     }
 
-    public async Task<KeycloakBaseResponse> AssignClientRoleToUser(string userId, string roleId, string roleName)
+    public async Task<KeycloakBaseResponse> AssignClientRoleToUser(string userId, string roleId, string roleName, CancellationToken cancellationToken = default)
     {
         var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{userId}/role-mappings/clients/{keyCloakConfiguration.Value.ClientUuid}";
 
@@ -41,7 +41,7 @@ public sealed class RoleManagement(IHttpClientFactory httpClientFactory, IOption
             Content = new StringContent(JsonSerializer.Serialize(roles), Encoding.UTF8, "application/json")
         };
 
-        var response = await _httpClient.SendAsync(request);
+        var response = await _httpClient.SendAsync(request, cancellationToken);
 
         return await response.HandleResponseAsync();
     }

--- a/Keycloak.Net.Sdk/Users/Contracts/IUserManagement.cs
+++ b/Keycloak.Net.Sdk/Users/Contracts/IUserManagement.cs
@@ -9,8 +9,8 @@ public interface IUserManagement
     Task<KeycloakBaseResponse<SigninResponseDto>> SigninAsync(string username, string password, CancellationToken cancellationToken = default);
     Task<KeycloakBaseResponse<UserInfoResponseDto>> GetUserAsync(string id, CancellationToken cancellationToken = default);
     Task<KeycloakBaseResponse<List<UserInfoResponseDto>>> GetUserByUsernameAsync(string username, CancellationToken cancellationToken = default);
-    Task EnableUserAsync(string userId);
-    Task DisableUserAsync(string userId);
+    Task EnableUserAsync(string userId, CancellationToken cancellationToken = default);
+    Task DisableUserAsync(string userId, CancellationToken cancellationToken = default);
     Task SetUserPasswordAsync(string userId, string password, bool temporary = false, CancellationToken cancellationToken = default);
-    Task DeleteUserAsync(string userId, CancellationToken cancellation = default);
+    Task DeleteUserAsync(string userId, CancellationToken cancellationToken = default);
 }

--- a/Keycloak.Net.Sdk/Users/Contracts/SetUserPasswordRequestDto.cs
+++ b/Keycloak.Net.Sdk/Users/Contracts/SetUserPasswordRequestDto.cs
@@ -1,8 +1,15 @@
+using System.Text.Json.Serialization;
+
 namespace Keycloak.Net.Sdk.Users.Contracts;
 
 public sealed record SetUserPasswordRequestDto()
 {
+    [JsonPropertyName("type")]
     public string Type => "password";
+
+    [JsonPropertyName("value")]
     public string Value { get; init; }
+
+    [JsonPropertyName("temporary")]
     public bool Temporary { get; init; }
 }

--- a/Keycloak.Net.Sdk/Users/UserManagement.cs
+++ b/Keycloak.Net.Sdk/Users/UserManagement.cs
@@ -28,8 +28,6 @@ public sealed class UserManagement(IHttpClientFactory httpClientFactory, IOption
 
     public async Task<KeycloakBaseResponse<SigninResponseDto>> SigninAsync(string username, string password, CancellationToken cancellationToken = default)
     {
-        _httpClient.DefaultRequestHeaders.Authorization = null;
-
         var uri = new Uri($"realms/{keyCloakConfiguration.Value.RealmName}/protocol/openid-connect/token", UriKind.Relative);
 
         var requestData = new Dictionary<string, string>
@@ -41,13 +39,16 @@ public sealed class UserManagement(IHttpClientFactory httpClientFactory, IOption
             { "grant_type", "password" }
         };
 
-        var requestContent = new FormUrlEncodedContent(requestData);
+        var request = new HttpRequestMessage(HttpMethod.Post, uri)
+        {
+            Content = new FormUrlEncodedContent(requestData)
+        };
 
-        var response = await _httpClient.PostAsync(uri, requestContent, cancellationToken);
+        var response = await _httpClient.SendAsync(request, cancellationToken);
         return await response.HandleResponseAsync<SigninResponseDto>();
     }
 
-    public async Task<KeycloakBaseResponse<UserInfoResponseDto>> GetUserAsync(string id, CancellationToken cancellationToken)
+    public async Task<KeycloakBaseResponse<UserInfoResponseDto>> GetUserAsync(string id, CancellationToken cancellationToken = default)
     {
         var requestUrl = $"admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{id}";
         var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
@@ -66,12 +67,12 @@ public sealed class UserManagement(IHttpClientFactory httpClientFactory, IOption
 
         return await response.HandleResponseAsync<List<UserInfoResponseDto>>();
     }
-    
+
     public async Task SetUserPasswordAsync(string userId, string password, bool temporary = false, CancellationToken cancellationToken = default)
     {
         var uri = new Uri($"admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{userId}/reset-password", UriKind.Relative);
 
-        var passwordPayload = new SetUserPasswordRequestDto()
+        var passwordPayload = new SetUserPasswordRequestDto
         {
             Value = password,
             Temporary = temporary
@@ -85,19 +86,21 @@ public sealed class UserManagement(IHttpClientFactory httpClientFactory, IOption
         var response = await _httpClient.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
-    
-    public async Task DeleteUserAsync(string userId, CancellationToken cancellation = default)
+
+    public async Task DeleteUserAsync(string userId, CancellationToken cancellationToken = default)
     {
         var uri = new Uri($"admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{userId}", UriKind.Relative);
-        var response = await _httpClient.DeleteAsync(uri, cancellation);
+        var response = await _httpClient.DeleteAsync(uri, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
-    
-    public async Task EnableUserAsync(string userId) => await UpdateUserEnabledStatus(userId, true);
 
-    public async Task DisableUserAsync(string userId) => await UpdateUserEnabledStatus(userId, false);
+    public async Task EnableUserAsync(string userId, CancellationToken cancellationToken = default)
+        => await UpdateUserEnabledStatus(userId, true, cancellationToken);
 
-    private async Task UpdateUserEnabledStatus(string userId, bool enabled)
+    public async Task DisableUserAsync(string userId, CancellationToken cancellationToken = default)
+        => await UpdateUserEnabledStatus(userId, false, cancellationToken);
+
+    private async Task UpdateUserEnabledStatus(string userId, bool enabled, CancellationToken cancellationToken = default)
     {
         var uri = new Uri($"admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{userId}", UriKind.Relative);
         var payload = new { enabled };
@@ -107,9 +110,7 @@ public sealed class UserManagement(IHttpClientFactory httpClientFactory, IOption
             Content = new StringContent(JsonSerializer.Serialize(payload), Encoding.UTF8, "application/json")
         };
 
-        var response = await _httpClient.SendAsync(request);
+        var response = await _httpClient.SendAsync(request, cancellationToken);
         response.EnsureSuccessStatusCode();
     }
-    
- 
 }

--- a/Keycloak.Net.Sdk/Users/UserManagement.cs
+++ b/Keycloak.Net.Sdk/Users/UserManagement.cs
@@ -17,7 +17,6 @@ public sealed class UserManagement(IHttpClientFactory httpClientFactory, IOption
     public async Task<KeycloakBaseResponse> SignupAsync(SignupRequestDto requestDto, CancellationToken cancellationToken = default)
     {
         var uri = new Uri($"admin/realms/{keyCloakConfiguration.Value.RealmName}/users", UriKind.Relative);
-        var a = JsonSerializer.Serialize(requestDto);
         var request = new HttpRequestMessage(HttpMethod.Post, uri)
         {
             Content = new StringContent(JsonSerializer.Serialize(requestDto), Encoding.UTF8, "application/json")

--- a/Keycloak.Net.sln
+++ b/Keycloak.Net.sln
@@ -1,6 +1,10 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Keycloak.Net.Sdk", "Keycloak.Net.Sdk\Keycloak.Net.Sdk.csproj", "{869CDB1B-4AB4-4334-91EF-9C04DB9891F8}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Keycloak.Net.Sdk.UnitTests", "Keycloak.Net.Sdk.UnitTests\Keycloak.Net.Sdk.UnitTests.csproj", "{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Keycloak.Net.Sdk.IntegrationTests", "Keycloak.Net.Sdk.IntegrationTests\Keycloak.Net.Sdk.IntegrationTests.csproj", "{B2C3D4E5-F6A7-8901-BCDE-F12345678901}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -12,5 +16,13 @@ Global
 		{869CDB1B-4AB4-4334-91EF-9C04DB9891F8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{869CDB1B-4AB4-4334-91EF-9C04DB9891F8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{869CDB1B-4AB4-4334-91EF-9C04DB9891F8}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7890-ABCD-EF1234567890}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B2C3D4E5-F6A7-8901-BCDE-F12345678901}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -1,65 +1,166 @@
 # Keycloak.Net.Sdk
 
-> 🧰 A powerful and modular .NET SDK for integrating with [Keycloak](https://www.keycloak.org/)
+A modular .NET 8 SDK for integrating with [Keycloak](https://www.keycloak.org/) using `IHttpClientFactory`, typed services, and built-in retry policies.
 
-This SDK is designed to provide a clean, extensible, and testable interface to interact with Keycloak in .NET applications using `HttpClientFactory`, typed services, and native DTOs.
-
-📦 NuGet: [Keycloak.Net.Sdk](https://www.nuget.org/packages/Keycloak.Net.Sdk)
+📦 [NuGet: Keycloak.Net.Sdk](https://www.nuget.org/packages/Keycloak.Net.Sdk)
 
 ---
 
-## ✨ Features
+## Features
 
-- Sign up / Sign in users  
-- Manage users (set password, enable/disable, delete)  
-- Manage roles (realm & client)  
-- Assign / remove roles to users  
-- Manage realms and clients  
-- Token-based authentication  
-- Built-in retry policy & auth handler  
-- Supports `HttpClientFactory` and dependency injection  
+- Sign up / sign in users
+- Manage users (get, enable/disable, set password, delete)
+- Manage roles (get client roles, assign/remove roles)
+- Manage clients (get, create, delete, enable service accounts)
+- Manage client scopes
+- Manage realms
+- Token management (get service-account token, revoke token)
+- Built-in retry policy via Polly
+- Auth handler that automatically attaches Bearer tokens to requests
+- Fully supports `IHttpClientFactory` and dependency injection
 
 ---
 
+## Requirements
 
-### Prerequisites
+- .NET 8+
+- A running Keycloak server (v21+)
+- A confidential client with **Service Accounts Enabled**
 
-Before using the **Keycloak.Net** SDK, ensure you have the following:
+---
 
-- A **Keycloak** server running and accessible.
-- **.NET 8+** project setup.
-
-## ⚙️ Installation
+## Installation
 
 ```bash
 dotnet add package Keycloak.Net.Sdk
 ```
 
-## 🔧 Configuration 
+---
 
-1- Add this config to your appsettings.json
+## Configuration
 
+### 1. `appsettings.json`
+
+```json
+"keycloak": {
+  "ServerUrl": "https://your-keycloak-host/",
+  "RealmName": "your-realm",
+  "ClientId": "your-client-id",
+  "ClientSecret": "your-client-secret",
+  "ClientUuid": "your-client-uuid",
+  "AdminUsername": "admin",
+  "AdminPassword": "admin-password",
+  "NumberOfRetries": 3,
+  "DelayBetweenRetryRequestsInSeconds": 2
+}
 ```
-  "keycloak": {
-    "ServerUrl": "keycloak service address",
-    "RealmName": "your realm name",
-    "ClientId": "your clientId",
-    "ClientSecret":"your clientSecret",
-    "AdminUsername": "master realm username",
-    "AdminPassword": "master realm password",
-    "NumberOfRetries": 3,
-    "DelayBetweenRetryRequestsInSeconds": 1
-  }
-```
-2- Register to DI
-```
+
+| Field | Description |
+|-------|-------------|
+| `ServerUrl` | Keycloak base URL (include trailing slash) |
+| `RealmName` | The realm your client belongs to |
+| `ClientId` | Client ID (used for service-account token requests) |
+| `ClientSecret` | Client secret |
+| `ClientUuid` | Client UUID (used in Admin API calls) |
+| `AdminUsername` | Master realm admin username (for realm management) |
+| `AdminPassword` | Master realm admin password |
+| `NumberOfRetries` | Polly retry count (default: 3) |
+| `DelayBetweenRetryRequestsInSeconds` | Delay between retries (default: 2) |
+
+### 2. Register Services
+
+```csharp
 builder.Services.AddKeycloak(builder.Configuration);
 ```
 
-### License
-This project is licensed under the MIT License - see the LICENSE file for details.
+---
 
-### Contact
-For more information, questions, or feedback, you can reach out to me at miladrivandi73@gmail.com or open an issue in this repository.
+## Usage
 
+Inject the interface you need:
 
+```csharp
+public class MyService(IUserManagement users, IRoleManagement roles)
+{
+    public async Task CreateAndAssignAsync()
+    {
+        var signup = await users.SignupAsync(new SignupRequestDto
+        {
+            Username  = "john.doe",
+            Email     = "john@example.com",
+            FirstName = "John",
+            LastName  = "Doe",
+            Password  = "Secret@123"
+        });
+
+        await roles.AssignClientRoleToUser(userId: signup.Response.Id, roleId: "role-uuid");
+    }
+}
+```
+
+### Available Interfaces
+
+| Interface | Responsibilities |
+|-----------|-----------------|
+| `IUserManagement` | Sign up, sign in, get user, enable/disable, set password, delete |
+| `IRoleManagement` | Get client roles, assign/remove roles to users |
+| `IClientManagement` | Get clients, get client scopes, create/delete client, enable service accounts |
+| `IRealmManagement` | Create realm |
+| `ITokenManagement` | Get service-account token, revoke token |
+
+---
+
+## Running Tests
+
+### Unit Tests
+
+Unit tests use a fake `HttpMessageHandler` — no external dependencies required.
+
+```bash
+dotnet test Keycloak.Net.Sdk.UnitTests/Keycloak.Net.Sdk.UnitTests.csproj
+```
+
+### Integration Tests
+
+Integration tests spin up a real Keycloak instance via [Testcontainers](https://dotnet.testcontainers.org/). **Docker must be running.**
+
+```bash
+dotnet test Keycloak.Net.Sdk.IntegrationTests/Keycloak.Net.Sdk.IntegrationTests.csproj
+```
+
+> The first run pulls the Keycloak Docker image (~500 MB). Subsequent runs reuse the cached image.
+
+### All Tests
+
+```bash
+dotnet test
+```
+
+---
+
+## Project Structure
+
+```
+Keycloak.Net.Sdk/                  # SDK source
+├── Athentications/                # TokenProvider, TokenManagement, KeycloakAuthHandler
+├── Clients/                       # ClientManagement + DTOs
+├── Configurations/                # KeycloakConfiguration
+├── Contracts/                     # Shared response types (KeycloakBaseResponse)
+├── Extensions/                    # ServiceRegistrations, ExceptionHandler
+├── Realms/                        # RealmManagement
+├── Roles/                         # RoleManagement + DTOs
+└── Users/                         # UserManagement + DTOs
+
+Keycloak.Net.Sdk.UnitTests/        # Unit tests (Moq, FakeHttpMessageHandler)
+Keycloak.Net.Sdk.IntegrationTests/ # Integration tests (Testcontainers.Keycloak)
+```
+
+---
+
+## License
+
+[MIT](LICENSE)
+
+## Contact
+
+Questions or feedback: [miladrivandi73@gmail.com](mailto:miladrivandi73@gmail.com) or open an issue.


### PR DESCRIPTION
## Summary

This PR fixes several bugs in the SDK, adds full test coverage (unit + integration), and updates the README.

## Bug Fixes

- **ExceptionHandler**: Success responses were hardcoding `HttpStatusCode.OK` now preserves the actual HTTP status code from the response
- **ClientResponseDto**, **CreateClientRequestDto**, **UpdateClientStatusRequestDto**, **SetUserPasswordRequestDto**: All were missing `[JsonPropertyName]` attributes, causing Keycloak to reject requests or deserialize null values due to PascalCase vs camelCase mismatch
- **TokenProvider**: Was creating `new HttpClient()` directly instead of using `IHttpClientFactory`
- **TokenManagement**: Was using the `"keycloak"` named client (which attaches a Bearer token via `KeycloakAuthHandler`) for OAuth public endpoints switched to `"keycloak-token"` client
- **ServiceRegistrations**: Added null guard on config binding; registered `"keycloak-token"` named HttpClient

## Tests Added

- **Unit Tests** (`Keycloak.Net.Sdk.UnitTests`): 30 tests using a fake `HttpMessageHandler` no external dependencies, cover all public methods
- **Integration Tests** (`Keycloak.Net.Sdk.IntegrationTests`): 13 tests using Testcontainers.Keycloak spin up a real Keycloak Docker container and verify end-to-end behavior

## Documentation

- README rewritten with standardized structure, configuration table, interface overview, test running instructions, and project structure

## How to Test

```bash
# Unit tests (no Docker needed)
dotnet test Keycloak.Net.Sdk.UnitTests/

# Integration tests (requires Docker)
dotnet test Keycloak.Net.Sdk.IntegrationTests/
```