### PR TITLE
feat: Realm Role Management

### DIFF
--- a/Keycloak.Net.Sdk.IntegrationTests/KeycloakFixture.cs
+++ b/Keycloak.Net.Sdk.IntegrationTests/KeycloakFixture.cs
@@ -20,24 +20,26 @@ namespace Keycloak.Net.Sdk.IntegrationTests;
 ///   2. Create realm "sdk-integration"
 ///   3. Create confidential client with service accounts
 ///   4. Assign realm-admin role to service account → SDK can manage users/roles
-///   5. Create a test role inside the client
-///   6. Create a test user
+///   5. Create a test client role and a test realm role
+///   6. Create a test user and test group
 /// </summary>
 public class KeycloakFixture : IAsyncLifetime
 {
     private KeycloakContainer _container = null!;
 
     // ── Public state consumed by tests ────────────────────────────────────────
-    public IServiceProvider Services      { get; private set; } = null!;
-    public string           TestUserId    { get; private set; } = null!;
-    public string           TestRoleId    { get; private set; } = null!;
-    public string           TestGroupId   { get; private set; } = null!;
-    public const string     TestRoleName  = "sdk-test-role";
-    public const string     TestGroupName = "sdk-test-group";
-    public const string     TestUsername  = "sdk-test-user";
-    public const string     TestPassword  = "Test@1234";
-    public const string     Realm         = "sdk-integration";
-    public const string     SdkClientId   = "sdk-client";
+    public IServiceProvider Services          { get; private set; } = null!;
+    public string           TestUserId        { get; private set; } = null!;
+    public string           TestRoleId        { get; private set; } = null!;
+    public string           TestGroupId       { get; private set; } = null!;
+    public string           TestRealmRoleId   { get; private set; } = null!;
+    public const string     TestRoleName      = "sdk-test-role";
+    public const string     TestRealmRoleName = "sdk-test-realm-role";
+    public const string     TestGroupName     = "sdk-test-group";
+    public const string     TestUsername      = "sdk-test-user";
+    public const string     TestPassword      = "Test@1234";
+    public const string     Realm             = "sdk-integration";
+    public const string     SdkClientId       = "sdk-client";
 
     private const string AdminUsername = "admin";
     private const string AdminPassword = "admin";
@@ -63,13 +65,12 @@ public class KeycloakFixture : IAsyncLifetime
         // 4. Give service account realm-admin role
         await AssignRealmAdminToServiceAccountAsync(http, adminToken, Realm, clientUuid, SdkClientId);
 
-        // 5. Create test role inside the client
-        TestRoleId = await CreateClientRoleAsync(http, adminToken, Realm, clientUuid, TestRoleName);
+        // 5. Create test client role and realm role
+        TestRoleId      = await CreateClientRoleAsync(http, adminToken, Realm, clientUuid, TestRoleName);
+        TestRealmRoleId = await CreateRealmRoleAsync(http, adminToken, Realm, TestRealmRoleName);
 
-        // 6. Create test user
-        TestUserId = await CreateTestUserAsync(http, adminToken, Realm, TestUsername, TestPassword);
-
-        // 7. Create test group
+        // 6. Create test user and group
+        TestUserId  = await CreateTestUserAsync(http, adminToken, Realm, TestUsername, TestPassword);
         TestGroupId = await CreateGroupAsync(http, adminToken, Realm, TestGroupName);
 
         // 7. Wire up the SDK
@@ -178,6 +179,20 @@ public class KeycloakFixture : IAsyncLifetime
 
         // Fetch the created role to get its ID
         var getRoleReq  = AuthorizedGet($"admin/realms/{realm}/clients/{clientUuid}/roles/{roleName}", token);
+        var getRoleResp = await http.SendAsync(getRoleReq);
+        getRoleResp.EnsureSuccessStatusCode();
+        var json = JsonDocument.Parse(await getRoleResp.Content.ReadAsStringAsync());
+        return json.RootElement.GetProperty("id").GetString()!;
+    }
+
+    private static async Task<string> CreateRealmRoleAsync(
+        HttpClient http, string token, string realm, string roleName)
+    {
+        var req  = AuthorizedPost($"admin/realms/{realm}/roles", token, new { name = roleName, description = "SDK integration test realm role" });
+        var resp = await http.SendAsync(req);
+        resp.EnsureSuccessStatusCode();
+
+        var getRoleReq  = AuthorizedGet($"admin/realms/{realm}/roles/{roleName}", token);
         var getRoleResp = await http.SendAsync(getRoleReq);
         getRoleResp.EnsureSuccessStatusCode();
         var json = JsonDocument.Parse(await getRoleResp.Content.ReadAsStringAsync());

--- a/Keycloak.Net.Sdk.IntegrationTests/SdkIntegrationTests.cs
+++ b/Keycloak.Net.Sdk.IntegrationTests/SdkIntegrationTests.cs
@@ -301,3 +301,146 @@ public class GroupManagementIntegrationTests(KeycloakFixture fixture)
         Assert.DoesNotContain(result.Response, g => g.Id == fixture.TestGroupId);
     }
 }
+
+[Collection(nameof(KeycloakCollection))]
+public class RealmRoleManagementIntegrationTests(KeycloakFixture fixture)
+{
+    private IRoleManagement  Role  => fixture.Services.CreateScope().ServiceProvider.GetRequiredService<IRoleManagement>();
+    private IGroupManagement Group => fixture.Services.CreateScope().ServiceProvider.GetRequiredService<IGroupManagement>();
+
+    // ── Read ──────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetRealmRolesAsync_ReturnsCreatedTestRole()
+    {
+        var result = await Role.GetRealmRolesAsync();
+
+        Assert.True(result.IsSuccessful);
+        Assert.Contains(result.Response, r => r.Name == KeycloakFixture.TestRealmRoleName);
+        Assert.All(result.Response, r => Assert.False(r.ClientRole));
+    }
+
+    [Fact]
+    public async Task GetRealmRoleAsync_WithValidName_ReturnsSingleRole()
+    {
+        var result = await Role.GetRealmRoleAsync(KeycloakFixture.TestRealmRoleName);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(fixture.TestRealmRoleId, result.Response.Id);
+        Assert.Equal(KeycloakFixture.TestRealmRoleName, result.Response.Name);
+        Assert.False(result.Response.ClientRole);
+    }
+
+    [Fact]
+    public async Task GetRealmRoleAsync_WithInvalidName_ReturnsFailure()
+    {
+        var result = await Role.GetRealmRoleAsync("non-existent-role");
+
+        Assert.False(result.IsSuccessful);
+    }
+
+    // ── Create / Delete round-trip ────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateAndDeleteRealmRoleAsync_WorksRoundTrip()
+    {
+        var roleName = $"temp-realm-role-{Guid.NewGuid():N}";
+
+        // Create
+        var created = await Role.CreateRealmRoleAsync(new CreateRealmRoleRequestDto
+        {
+            Name        = roleName,
+            Description = "Temporary integration test role"
+        });
+        Assert.True(created.IsSuccessful);
+
+        // Verify it exists
+        var fetched = await Role.GetRealmRoleAsync(roleName);
+        Assert.True(fetched.IsSuccessful);
+        Assert.Equal(roleName, fetched.Response.Name);
+
+        // Delete
+        var deleted = await Role.DeleteRealmRoleAsync(roleName);
+        Assert.True(deleted.IsSuccessful);
+
+        // Verify it no longer exists
+        var afterDelete = await Role.GetRealmRoleAsync(roleName);
+        Assert.False(afterDelete.IsSuccessful);
+    }
+
+    // ── Realm Role ↔ User ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AssignAndRemoveRealmRoleToUser_WorksRoundTrip()
+    {
+        // Assign
+        var assign = await Role.AssignRealmRoleToUserAsync(
+            fixture.TestUserId, fixture.TestRealmRoleId, KeycloakFixture.TestRealmRoleName);
+        Assert.True(assign.IsSuccessful);
+
+        // Verify assignment
+        var userRoles = await Role.GetUserRealmRolesAsync(fixture.TestUserId);
+        Assert.True(userRoles.IsSuccessful);
+        Assert.Contains(userRoles.Response, r => r.Id == fixture.TestRealmRoleId);
+
+        // Remove
+        var remove = await Role.RemoveRealmRoleFromUserAsync(
+            fixture.TestUserId, fixture.TestRealmRoleId, KeycloakFixture.TestRealmRoleName);
+        Assert.True(remove.IsSuccessful);
+
+        // Verify removal
+        var after = await Role.GetUserRealmRolesAsync(fixture.TestUserId);
+        Assert.DoesNotContain(after.Response, r => r.Id == fixture.TestRealmRoleId);
+    }
+
+    [Fact]
+    public async Task GetUserRealmRolesAsync_WhenNoRolesAssigned_DoesNotContainTestRole()
+    {
+        // Ensure clean state
+        await Role.RemoveRealmRoleFromUserAsync(
+            fixture.TestUserId, fixture.TestRealmRoleId, KeycloakFixture.TestRealmRoleName);
+
+        var result = await Role.GetUserRealmRolesAsync(fixture.TestUserId);
+
+        Assert.True(result.IsSuccessful);
+        Assert.DoesNotContain(result.Response, r => r.Id == fixture.TestRealmRoleId);
+    }
+
+    // ── Realm Role ↔ Group ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AssignAndRemoveRealmRoleToGroup_WorksRoundTrip()
+    {
+        // Assign
+        var assign = await Role.AssignRealmRoleToGroupAsync(
+            fixture.TestGroupId, fixture.TestRealmRoleId, KeycloakFixture.TestRealmRoleName);
+        Assert.True(assign.IsSuccessful);
+
+        // Verify assignment
+        var groupRoles = await Role.GetGroupRealmRolesAsync(fixture.TestGroupId);
+        Assert.True(groupRoles.IsSuccessful);
+        Assert.Contains(groupRoles.Response, r => r.Id == fixture.TestRealmRoleId);
+
+        // Remove
+        var remove = await Role.RemoveRealmRoleFromGroupAsync(
+            fixture.TestGroupId, fixture.TestRealmRoleId, KeycloakFixture.TestRealmRoleName);
+        Assert.True(remove.IsSuccessful);
+
+        // Verify removal
+        var after = await Role.GetGroupRealmRolesAsync(fixture.TestGroupId);
+        Assert.DoesNotContain(after.Response, r => r.Id == fixture.TestRealmRoleId);
+    }
+
+    [Fact]
+    public async Task GetGroupRealmRolesAsync_WhenNoRolesAssigned_DoesNotContainTestRole()
+    {
+        // Ensure clean state
+        await Role.RemoveRealmRoleFromGroupAsync(
+            fixture.TestGroupId, fixture.TestRealmRoleId, KeycloakFixture.TestRealmRoleName);
+
+        var result = await Role.GetGroupRealmRolesAsync(fixture.TestGroupId);
+
+        Assert.True(result.IsSuccessful);
+        Assert.DoesNotContain(result.Response, r => r.Id == fixture.TestRealmRoleId);
+    }
+}

--- a/Keycloak.Net.Sdk.UnitTests/Helpers/TestData.cs
+++ b/Keycloak.Net.Sdk.UnitTests/Helpers/TestData.cs
@@ -92,4 +92,20 @@ public static class TestData
         """;
 
     public static string GroupsResponse => $"[{GroupResponse}]";
+
+    public const string RealmRoleId   = "realm-role-id-xyz";
+    public const string RealmRoleName = "test-realm-role";
+
+    public static string RealmRoleResponse => $$"""
+        {
+            "id": "{{RealmRoleId}}",
+            "name": "{{RealmRoleName}}",
+            "description": "Test realm role",
+            "composite": false,
+            "clientRole": false,
+            "containerId": "{{RealmName}}"
+        }
+        """;
+
+    public static string RealmRolesResponse => $"[{RealmRoleResponse}]";
 }

--- a/Keycloak.Net.Sdk.UnitTests/RoleManagementTests.cs
+++ b/Keycloak.Net.Sdk.UnitTests/RoleManagementTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using Keycloak.Net.Sdk.Configurations;
 using Keycloak.Net.Sdk.Roles;
+using Keycloak.Net.Sdk.Roles.Contracts;
 using Keycloak.Net.Sdk.UnitTests.Helpers;
 using Microsoft.Extensions.Options;
 using Xunit;
@@ -87,5 +88,187 @@ public class RoleManagementTests
         Assert.Contains($"users/{TestData.UserId}/role-mappings/clients/{TestData.ClientUuid}",
             handler.SentRequests[0].RequestUri!.ToString());
         Assert.Equal(HttpMethod.Delete, handler.SentRequests[0].Method);
+    }
+
+    // ── GetRealmRolesAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetRealmRolesAsync_Success_ReturnsRealmRoleList()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.RealmRolesResponse);
+
+        var result = await sut.GetRealmRolesAsync();
+
+        Assert.True(result.IsSuccessful);
+        Assert.Single(result.Response);
+        Assert.Equal(TestData.RealmRoleId, result.Response[0].Id);
+        Assert.Equal(TestData.RealmRoleName, result.Response[0].Name);
+        Assert.False(result.Response[0].ClientRole);
+        Assert.Contains($"realms/{TestData.RealmName}/roles", handler.SentRequests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Get, handler.SentRequests[0].Method);
+    }
+
+    [Fact]
+    public async Task GetRealmRolesAsync_Failure_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.Unauthorized);
+
+        var result = await sut.GetRealmRolesAsync();
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.Unauthorized, result.StatusCode);
+    }
+
+    // ── GetRealmRoleAsync ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetRealmRoleAsync_Success_ReturnsSingleRole()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.RealmRoleResponse);
+
+        var result = await sut.GetRealmRoleAsync(TestData.RealmRoleName);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(TestData.RealmRoleId, result.Response.Id);
+        Assert.Equal(TestData.RealmRoleName, result.Response.Name);
+        Assert.Contains($"roles/{TestData.RealmRoleName}", handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    // ── CreateRealmRoleAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreateRealmRoleAsync_Success_SendsPostWithRoleBody()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.Created);
+
+        var request = new CreateRealmRoleRequestDto { Name = TestData.RealmRoleName, Description = "Test realm role" };
+        var result = await sut.CreateRealmRoleAsync(request);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Post, handler.SentRequests[0].Method);
+        Assert.Contains($"realms/{TestData.RealmName}/roles", handler.SentRequests[0].RequestUri!.ToString());
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains(TestData.RealmRoleName, body);
+    }
+
+    // ── DeleteRealmRoleAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeleteRealmRoleAsync_Success_SendsDeleteRequest()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.DeleteRealmRoleAsync(TestData.RealmRoleName);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Delete, handler.SentRequests[0].Method);
+        Assert.Contains($"roles/{TestData.RealmRoleName}", handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    // ── GetUserRealmRolesAsync ────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetUserRealmRolesAsync_Success_ReturnsRoleList()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.RealmRolesResponse);
+
+        var result = await sut.GetUserRealmRolesAsync(TestData.UserId);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Single(result.Response);
+        Assert.Contains($"users/{TestData.UserId}/role-mappings/realm", handler.SentRequests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Get, handler.SentRequests[0].Method);
+    }
+
+    // ── AssignRealmRoleToUserAsync ────────────────────────────────────────────
+
+    [Fact]
+    public async Task AssignRealmRoleToUserAsync_Success_SendsPostWithRoleBody()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.AssignRealmRoleToUserAsync(TestData.UserId, TestData.RealmRoleId, TestData.RealmRoleName);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Post, handler.SentRequests[0].Method);
+        Assert.Contains($"users/{TestData.UserId}/role-mappings/realm", handler.SentRequests[0].RequestUri!.ToString());
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains(TestData.RealmRoleId, body);
+        Assert.Contains(TestData.RealmRoleName, body);
+    }
+
+    // ── RemoveRealmRoleFromUserAsync ──────────────────────────────────────────
+
+    [Fact]
+    public async Task RemoveRealmRoleFromUserAsync_Success_SendsDeleteRequest()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.RemoveRealmRoleFromUserAsync(TestData.UserId, TestData.RealmRoleId, TestData.RealmRoleName);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Delete, handler.SentRequests[0].Method);
+        Assert.Contains($"users/{TestData.UserId}/role-mappings/realm", handler.SentRequests[0].RequestUri!.ToString());
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains(TestData.RealmRoleId, body);
+    }
+
+    // ── GetGroupRealmRolesAsync ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetGroupRealmRolesAsync_Success_ReturnsRoleList()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.RealmRolesResponse);
+
+        var result = await sut.GetGroupRealmRolesAsync(TestData.GroupId);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Single(result.Response);
+        Assert.Contains($"groups/{TestData.GroupId}/role-mappings/realm", handler.SentRequests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Get, handler.SentRequests[0].Method);
+    }
+
+    // ── AssignRealmRoleToGroupAsync ───────────────────────────────────────────
+
+    [Fact]
+    public async Task AssignRealmRoleToGroupAsync_Success_SendsPostWithRoleBody()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.AssignRealmRoleToGroupAsync(TestData.GroupId, TestData.RealmRoleId, TestData.RealmRoleName);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Post, handler.SentRequests[0].Method);
+        Assert.Contains($"groups/{TestData.GroupId}/role-mappings/realm", handler.SentRequests[0].RequestUri!.ToString());
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains(TestData.RealmRoleId, body);
+        Assert.Contains(TestData.RealmRoleName, body);
+    }
+
+    // ── RemoveRealmRoleFromGroupAsync ─────────────────────────────────────────
+
+    [Fact]
+    public async Task RemoveRealmRoleFromGroupAsync_Success_SendsDeleteRequest()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.RemoveRealmRoleFromGroupAsync(TestData.GroupId, TestData.RealmRoleId, TestData.RealmRoleName);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Delete, handler.SentRequests[0].Method);
+        Assert.Contains($"groups/{TestData.GroupId}/role-mappings/realm", handler.SentRequests[0].RequestUri!.ToString());
+        var body = await handler.SentRequests[0].Content!.ReadAsStringAsync();
+        Assert.Contains(TestData.RealmRoleId, body);
     }
 }

--- a/Keycloak.Net.Sdk/Roles/Contracts/CreateRealmRoleRequestDto.cs
+++ b/Keycloak.Net.Sdk/Roles/Contracts/CreateRealmRoleRequestDto.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Keycloak.Net.Sdk.Roles.Contracts;
+
+public sealed record CreateRealmRoleRequestDto
+{
+    [JsonPropertyName("name")]
+    public required string Name { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+}

--- a/Keycloak.Net.Sdk/Roles/Contracts/IRoleManagement.cs
+++ b/Keycloak.Net.Sdk/Roles/Contracts/IRoleManagement.cs
@@ -4,7 +4,24 @@ namespace Keycloak.Net.Sdk.Roles.Contracts;
 
 public interface IRoleManagement
 {
+    // ── Client Roles ──────────────────────────────────────────────────────────
     Task<KeycloakBaseResponse<List<ClientRoleResponseDto>>> GetClientRoles(CancellationToken cancellationToken = default);
     Task<KeycloakBaseResponse> AssignClientRoleToUser(string userId, string roleId, string roleName, CancellationToken cancellationToken = default);
     Task<KeycloakBaseResponse> RemoveClientRoleFromUserAsync(string userId, string roleId, string roleName, CancellationToken cancellationToken = default);
+
+    // ── Realm Roles ───────────────────────────────────────────────────────────
+    Task<KeycloakBaseResponse<List<RealmRoleResponseDto>>> GetRealmRolesAsync(CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse<RealmRoleResponseDto>> GetRealmRoleAsync(string roleName, CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse> CreateRealmRoleAsync(CreateRealmRoleRequestDto requestDto, CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse> DeleteRealmRoleAsync(string roleName, CancellationToken cancellationToken = default);
+
+    // ── Realm Role ↔ User ─────────────────────────────────────────────────────
+    Task<KeycloakBaseResponse<List<RealmRoleResponseDto>>> GetUserRealmRolesAsync(string userId, CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse> AssignRealmRoleToUserAsync(string userId, string roleId, string roleName, CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse> RemoveRealmRoleFromUserAsync(string userId, string roleId, string roleName, CancellationToken cancellationToken = default);
+
+    // ── Realm Role ↔ Group ────────────────────────────────────────────────────
+    Task<KeycloakBaseResponse<List<RealmRoleResponseDto>>> GetGroupRealmRolesAsync(string groupId, CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse> AssignRealmRoleToGroupAsync(string groupId, string roleId, string roleName, CancellationToken cancellationToken = default);
+    Task<KeycloakBaseResponse> RemoveRealmRoleFromGroupAsync(string groupId, string roleId, string roleName, CancellationToken cancellationToken = default);
 }

--- a/Keycloak.Net.Sdk/Roles/Contracts/RealmRoleResponseDto.cs
+++ b/Keycloak.Net.Sdk/Roles/Contracts/RealmRoleResponseDto.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Keycloak.Net.Sdk.Roles.Contracts;
+
+public sealed record RealmRoleResponseDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; set; }
+
+    [JsonPropertyName("name")]
+    public string Name { get; set; }
+
+    [JsonPropertyName("description")]
+    public string? Description { get; set; }
+
+    [JsonPropertyName("composite")]
+    public bool Composite { get; set; }
+
+    [JsonPropertyName("clientRole")]
+    public bool ClientRole { get; set; }
+
+    [JsonPropertyName("containerId")]
+    public string ContainerId { get; set; }
+}

--- a/Keycloak.Net.Sdk/Roles/RoleManagement.cs
+++ b/Keycloak.Net.Sdk/Roles/RoleManagement.cs
@@ -68,4 +68,138 @@ public sealed class RoleManagement(IHttpClientFactory httpClientFactory, IOption
 
         return await response.HandleResponseAsync();
     }
+
+    // ── Realm Roles ───────────────────────────────────────────────────────────
+
+    public async Task<KeycloakBaseResponse<List<RealmRoleResponseDto>>> GetRealmRolesAsync(CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/roles";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync<List<RealmRoleResponseDto>>();
+    }
+
+    public async Task<KeycloakBaseResponse<RealmRoleResponseDto>> GetRealmRoleAsync(string roleName, CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/roles/{roleName}";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync<RealmRoleResponseDto>();
+    }
+
+    public async Task<KeycloakBaseResponse> CreateRealmRoleAsync(CreateRealmRoleRequestDto requestDto, CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/roles";
+
+        var request = new HttpRequestMessage(HttpMethod.Post, requestUrl)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(requestDto), Encoding.UTF8, "application/json")
+        };
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync();
+    }
+
+    public async Task<KeycloakBaseResponse> DeleteRealmRoleAsync(string roleName, CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/roles/{roleName}";
+        var request = new HttpRequestMessage(HttpMethod.Delete, requestUrl);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync();
+    }
+
+    // ── Realm Role ↔ User ─────────────────────────────────────────────────────
+
+    public async Task<KeycloakBaseResponse<List<RealmRoleResponseDto>>> GetUserRealmRolesAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{userId}/role-mappings/realm";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync<List<RealmRoleResponseDto>>();
+    }
+
+    public async Task<KeycloakBaseResponse> AssignRealmRoleToUserAsync(string userId, string roleId, string roleName, CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{userId}/role-mappings/realm";
+
+        var roles = new[] { new { id = roleId, name = roleName } };
+
+        var request = new HttpRequestMessage(HttpMethod.Post, requestUrl)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(roles), Encoding.UTF8, "application/json")
+        };
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync();
+    }
+
+    public async Task<KeycloakBaseResponse> RemoveRealmRoleFromUserAsync(string userId, string roleId, string roleName, CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{userId}/role-mappings/realm";
+
+        var roles = new[] { new { id = roleId, name = roleName } };
+
+        var request = new HttpRequestMessage(HttpMethod.Delete, requestUrl)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(roles), Encoding.UTF8, "application/json")
+        };
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync();
+    }
+
+    // ── Realm Role ↔ Group ────────────────────────────────────────────────────
+
+    public async Task<KeycloakBaseResponse<List<RealmRoleResponseDto>>> GetGroupRealmRolesAsync(string groupId, CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/groups/{groupId}/role-mappings/realm";
+        var request = new HttpRequestMessage(HttpMethod.Get, requestUrl);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync<List<RealmRoleResponseDto>>();
+    }
+
+    public async Task<KeycloakBaseResponse> AssignRealmRoleToGroupAsync(string groupId, string roleId, string roleName, CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/groups/{groupId}/role-mappings/realm";
+
+        var roles = new[] { new { id = roleId, name = roleName } };
+
+        var request = new HttpRequestMessage(HttpMethod.Post, requestUrl)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(roles), Encoding.UTF8, "application/json")
+        };
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync();
+    }
+
+    public async Task<KeycloakBaseResponse> RemoveRealmRoleFromGroupAsync(string groupId, string roleId, string roleName, CancellationToken cancellationToken = default)
+    {
+        var requestUrl = $"/admin/realms/{keyCloakConfiguration.Value.RealmName}/groups/{groupId}/role-mappings/realm";
+
+        var roles = new[] { new { id = roleId, name = roleName } };
+
+        var request = new HttpRequestMessage(HttpMethod.Delete, requestUrl)
+        {
+            Content = new StringContent(JsonSerializer.Serialize(roles), Encoding.UTF8, "application/json")
+        };
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+
+        return await response.HandleResponseAsync();
+    }
 }

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ A modular .NET 8 SDK for integrating with [Keycloak](https://www.keycloak.org/) 
 
 - Sign up / sign in users
 - Manage users (get, enable/disable, set password, delete)
-- Manage roles (get client roles, assign/remove roles)
+- Manage client roles (get, assign/remove to users)
+- Manage realm roles (get, create, delete, assign/remove to users and groups)
 - Manage clients (get, create, delete, enable service accounts)
 - Manage client scopes
 - Manage realms
@@ -99,6 +100,35 @@ public class MyService(IUserManagement users, IRoleManagement roles)
 }
 ```
 
+Use `IRoleManagement` for both client roles and realm roles:
+
+```csharp
+public class RoleService(IRoleManagement roles)
+{
+    // Realm role CRUD
+    public async Task CreateRealmRoleAsync()
+    {
+        await roles.CreateRealmRoleAsync(new CreateRealmRoleRequestDto
+        {
+            Name        = "admin",
+            Description = "Full access role"
+        });
+    }
+
+    // Assign a realm role to a user
+    public async Task AssignRealmRoleToUserAsync(string userId, string roleId, string roleName)
+    {
+        await roles.AssignRealmRoleToUserAsync(userId, roleId, roleName);
+    }
+
+    // Assign a realm role to a group
+    public async Task AssignRealmRoleToGroupAsync(string groupId, string roleId, string roleName)
+    {
+        await roles.AssignRealmRoleToGroupAsync(groupId, roleId, roleName);
+    }
+}
+```
+
 Or use `IGroupManagement` to organize users into groups:
 
 ```csharp
@@ -122,7 +152,7 @@ public class GroupService(IGroupManagement groups)
 | Interface | Responsibilities |
 |-----------|-----------------|
 | `IUserManagement` | Sign up, sign in, get user, enable/disable, set password, delete |
-| `IRoleManagement` | Get client roles, assign/remove roles to users |
+| `IRoleManagement` | Client roles: get, assign/remove to users. Realm roles: get, create, delete, assign/remove to users and groups |
 | `IClientManagement` | Get clients, get client scopes, create/delete client, enable service accounts |
 | `IRealmManagement` | Create realm |
 | `ITokenManagement` | Get service-account token, revoke token |
@@ -134,7 +164,7 @@ public class GroupService(IGroupManagement groups)
 
 ### Unit Tests
 
-Unit tests use a fake `HttpMessageHandler` — no external dependencies required.
+Unit tests use a fake `HttpMessageHandler`  no external dependencies required.
 
 ```bash
 dotnet test Keycloak.Net.Sdk.UnitTests/Keycloak.Net.Sdk.UnitTests.csproj
@@ -153,7 +183,7 @@ The fixture automatically handles the full setup sequence:
 2. Creates a dedicated test realm
 3. Creates a confidential client with service accounts
 4. Grants realm-admin role to the service account
-5. Creates a test user, test role, and test group
+5. Creates a test user, client role, realm role, and group
 
 > The first run pulls the Keycloak Docker image (~500 MB). Subsequent runs reuse the cached image.
 


### PR DESCRIPTION
## Summary

Adds full realm-level role management alongside the existing client role support.

## Changes

**SDK (`Keycloak.Net.Sdk`)**
- `Roles/Contracts/RealmRoleResponseDto.cs` new DTO
- `Roles/Contracts/CreateRealmRoleRequestDto.cs` new DTO
- `IRoleManagement` 10 new methods across three groups:
  - Realm role CRUD: `GetRealmRolesAsync`, `GetRealmRoleAsync`, `CreateRealmRoleAsync`, `DeleteRealmRoleAsync`
  - User assignment: `GetUserRealmRolesAsync`, `AssignRealmRoleToUserAsync`, `RemoveRealmRoleFromUserAsync`
  - Group assignment: `GetGroupRealmRolesAsync`, `AssignRealmRoleToGroupAsync`, `RemoveRealmRoleFromGroupAsync`
- `RoleManagement` implements all 10 methods

**Tests**
- `RoleManagementTests` 12 new unit tests (success + failure paths for each method)
- `SdkIntegrationTests`,  `RealmRoleManagementIntegrationTests` class with 9 tests covering read, create/delete round-trip, user assignment round-trip, and group assignment round-trip
- `KeycloakFixture` seeds a `TestRealmRoleId` / `TestRealmRoleName` at container startup

## API endpoints used

| Method | Endpoint |
|---|---|
| GET | `/admin/realms/{realm}/roles` |
| GET | `/admin/realms/{realm}/roles/{role-name}` |
| POST | `/admin/realms/{realm}/roles` |
| DELETE | `/admin/realms/{realm}/roles/{role-name}` |
| GET/POST/DELETE | `/admin/realms/{realm}/users/{id}/role-mappings/realm` |
| GET/POST/DELETE | `/admin/realms/{realm}/groups/{id}/role-mappings/realm` |