### PR TITLE
feat: Add User Session Management

### DIFF
--- a/Keycloak.Net.Sdk.UnitTests/Helpers/TestData.cs
+++ b/Keycloak.Net.Sdk.UnitTests/Helpers/TestData.cs
@@ -108,4 +108,23 @@ public static class TestData
         """;
 
     public static string RealmRolesResponse => $"[{RealmRoleResponse}]";
+
+    public const string SessionId = "session-id-xyz";
+
+    public static string UserSessionResponse => $$"""
+        {
+            "id": "{{SessionId}}",
+            "username": "{{Username}}",
+            "userId": "{{UserId}}",
+            "ipAddress": "127.0.0.1",
+            "start": 1700000000000,
+            "lastAccess": 1700000001000,
+            "rememberMe": false,
+            "clients": {
+                "{{ClientUuid}}": "{{ClientId}}"
+            }
+        }
+        """;
+
+    public static string UserSessionsResponse => $"[{UserSessionResponse}]";
 }

--- a/Keycloak.Net.Sdk.UnitTests/UserSessionManagementTests.cs
+++ b/Keycloak.Net.Sdk.UnitTests/UserSessionManagementTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using Keycloak.Net.Sdk.Configurations;
+using Keycloak.Net.Sdk.UserSessions;
+using Keycloak.Net.Sdk.UserSessions.Contracts;
+using Keycloak.Net.Sdk.UnitTests.Helpers;
+using Microsoft.Extensions.Options;
+using Xunit;
+
+namespace Keycloak.Net.Sdk.UnitTests;
+
+public class UserSessionManagementTests
+{
+    private readonly IOptions<KeycloakConfiguration> _options = Options.Create(new KeycloakConfiguration
+    {
+        ServerUrl    = "http://localhost:8080/",
+        RealmName    = TestData.RealmName,
+        ClientId     = TestData.ClientId,
+        ClientSecret = TestData.ClientSecret,
+        ClientUuid   = TestData.ClientUuid
+    });
+
+    private (UserSessionManagement Sut, FakeHttpMessageHandler Handler) CreateSut()
+    {
+        var (factory, handler) = HttpClientFactoryHelper.Create();
+        return (new UserSessionManagement(factory, _options), handler);
+    }
+
+    // ── GetUserSessionsAsync ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetUserSessionsAsync_Success_ReturnsSessionList()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.OK, TestData.UserSessionsResponse);
+
+        var result = await sut.GetUserSessionsAsync(TestData.UserId);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Single(result.Response);
+        var session = result.Response[0];
+        Assert.Equal(TestData.SessionId, session.Id);
+        Assert.Equal(TestData.Username, session.Username);
+        Assert.Equal(TestData.UserId, session.UserId);
+        Assert.Equal("127.0.0.1", session.IpAddress);
+        Assert.Contains($"users/{TestData.UserId}/sessions", handler.SentRequests[0].RequestUri!.ToString());
+        Assert.Equal(HttpMethod.Get, handler.SentRequests[0].Method);
+    }
+
+    [Fact]
+    public async Task GetUserSessionsAsync_UserNotFound_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NotFound);
+
+        var result = await sut.GetUserSessionsAsync("nonexistent-user");
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+    }
+
+    // ── RevokeSessionAsync ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RevokeSessionAsync_Success_SendsDeleteToCorrectUrl()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.RevokeSessionAsync(TestData.SessionId);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Delete, handler.SentRequests[0].Method);
+        Assert.Contains($"sessions/{TestData.SessionId}", handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task RevokeSessionAsync_SessionNotFound_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NotFound);
+
+        var result = await sut.RevokeSessionAsync("nonexistent-session");
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+    }
+
+    // ── LogoutUserAsync ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task LogoutUserAsync_Success_SendsPostToLogoutUrl()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NoContent);
+
+        var result = await sut.LogoutUserAsync(TestData.UserId);
+
+        Assert.True(result.IsSuccessful);
+        Assert.Equal(HttpMethod.Post, handler.SentRequests[0].Method);
+        Assert.Contains($"users/{TestData.UserId}/logout", handler.SentRequests[0].RequestUri!.ToString());
+    }
+
+    [Fact]
+    public async Task LogoutUserAsync_UserNotFound_ReturnsFailureResponse()
+    {
+        var (sut, handler) = CreateSut();
+        handler.AddResponse(HttpStatusCode.NotFound);
+
+        var result = await sut.LogoutUserAsync("nonexistent-user");
+
+        Assert.False(result.IsSuccessful);
+        Assert.Equal(HttpStatusCode.NotFound, result.StatusCode);
+    }
+}

--- a/Keycloak.Net.Sdk/Contracts/IKeycloakManagement.cs
+++ b/Keycloak.Net.Sdk/Contracts/IKeycloakManagement.cs
@@ -3,6 +3,7 @@ using Keycloak.Net.Sdk.Clients.Contracts;
 using Keycloak.Net.Sdk.Groups.Contracts;
 using Keycloak.Net.Sdk.Realms;
 using Keycloak.Net.Sdk.Roles.Contracts;
+using Keycloak.Net.Sdk.UserSessions.Contracts;
 using Keycloak.Net.Sdk.Users.Contracts;
 
 namespace Keycloak.Net.Sdk.Contracts;
@@ -15,4 +16,5 @@ public interface IKeycloakManagement
     public IRealmManagement RealmManagement { get; init; }
     public IClientManagement ClientManagement { get; init; }
     public IGroupManagement GroupManagement { get; init; }
+    public IUserSessionManagement UserSessionManagement { get; init; }
 }

--- a/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
+++ b/Keycloak.Net.Sdk/Extensions/ServiceRegistrations.cs
@@ -9,6 +9,8 @@ using Keycloak.Net.Sdk.Groups.Contracts;
 using Keycloak.Net.Sdk.Realms;
 using Keycloak.Net.Sdk.Roles;
 using Keycloak.Net.Sdk.Roles.Contracts;
+using Keycloak.Net.Sdk.UserSessions;
+using Keycloak.Net.Sdk.UserSessions.Contracts;
 using Keycloak.Net.Sdk.Users;
 using Keycloak.Net.Sdk.Users.Contracts;
 using Microsoft.Extensions.Configuration;
@@ -52,6 +54,7 @@ public static class ServiceRegistrations
         services.AddScoped<IRealmManagement, RealmManagement>();
         services.AddScoped<IClientManagement, ClientManagement>();
         services.AddScoped<IGroupManagement, GroupManagement>();
+        services.AddScoped<IUserSessionManagement, UserSessionManagement>();
 
         return services;
     }

--- a/Keycloak.Net.Sdk/KeycloakManagement.cs
+++ b/Keycloak.Net.Sdk/KeycloakManagement.cs
@@ -4,6 +4,7 @@ using Keycloak.Net.Sdk.Contracts;
 using Keycloak.Net.Sdk.Groups.Contracts;
 using Keycloak.Net.Sdk.Realms;
 using Keycloak.Net.Sdk.Roles.Contracts;
+using Keycloak.Net.Sdk.UserSessions.Contracts;
 using Keycloak.Net.Sdk.Users.Contracts;
 
 namespace Keycloak.Net.Sdk;
@@ -14,7 +15,8 @@ public sealed class KeycloakManagement(
     ITokenManagement tokenManagement,
     IRealmManagement realmManagement,
     IClientManagement clientManagement,
-    IGroupManagement groupManagement)
+    IGroupManagement groupManagement,
+    IUserSessionManagement userSessionManagement)
     : IKeycloakManagement
 {
     public IUserManagement UserManagement { get; init; } = userManagement;
@@ -23,4 +25,5 @@ public sealed class KeycloakManagement(
     public IRealmManagement RealmManagement { get; init; } = realmManagement;
     public IClientManagement ClientManagement { get; init; } = clientManagement;
     public IGroupManagement GroupManagement { get; init; } = groupManagement;
+    public IUserSessionManagement UserSessionManagement { get; init; } = userSessionManagement;
 }

--- a/Keycloak.Net.Sdk/UserSessions/Contracts/IUserSessionManagement.cs
+++ b/Keycloak.Net.Sdk/UserSessions/Contracts/IUserSessionManagement.cs
@@ -1,0 +1,15 @@
+using Keycloak.Net.Sdk.Contracts.Responses;
+
+namespace Keycloak.Net.Sdk.UserSessions.Contracts;
+
+public interface IUserSessionManagement
+{
+    /// <summary>Gets all active sessions for the specified user.</summary>
+    Task<KeycloakBaseResponse<List<UserSessionResponseDto>>> GetUserSessionsAsync(string userId, CancellationToken cancellationToken = default);
+
+    /// <summary>Revokes a specific session by its session ID.</summary>
+    Task<KeycloakBaseResponse> RevokeSessionAsync(string sessionId, CancellationToken cancellationToken = default);
+
+    /// <summary>Logs the user out of all active sessions.</summary>
+    Task<KeycloakBaseResponse> LogoutUserAsync(string userId, CancellationToken cancellationToken = default);
+}

--- a/Keycloak.Net.Sdk/UserSessions/Contracts/UserSessionResponseDto.cs
+++ b/Keycloak.Net.Sdk/UserSessions/Contracts/UserSessionResponseDto.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Keycloak.Net.Sdk.UserSessions.Contracts;
+
+public sealed record UserSessionResponseDto
+{
+    [JsonPropertyName("id")]
+    public string Id { get; init; } = null!;
+
+    [JsonPropertyName("username")]
+    public string Username { get; init; } = null!;
+
+    [JsonPropertyName("userId")]
+    public string UserId { get; init; } = null!;
+
+    [JsonPropertyName("ipAddress")]
+    public string IpAddress { get; init; } = null!;
+
+    [JsonPropertyName("start")]
+    public long Start { get; init; }
+
+    [JsonPropertyName("lastAccess")]
+    public long LastAccess { get; init; }
+
+    [JsonPropertyName("rememberMe")]
+    public bool RememberMe { get; init; }
+
+    [JsonPropertyName("clients")]
+    public Dictionary<string, string> Clients { get; init; } = new();
+}

--- a/Keycloak.Net.Sdk/UserSessions/UserSessionManagement.cs
+++ b/Keycloak.Net.Sdk/UserSessions/UserSessionManagement.cs
@@ -1,0 +1,38 @@
+using Keycloak.Net.Sdk.Configurations;
+using Keycloak.Net.Sdk.Contracts.Responses;
+using Keycloak.Net.Sdk.Extensions;
+using Keycloak.Net.Sdk.UserSessions.Contracts;
+using Microsoft.Extensions.Options;
+
+namespace Keycloak.Net.Sdk.UserSessions;
+
+public sealed class UserSessionManagement(IHttpClientFactory httpClientFactory, IOptions<KeycloakConfiguration> keyCloakConfiguration)
+    : IUserSessionManagement
+{
+    private readonly HttpClient _httpClient = httpClientFactory.CreateClient("keycloak");
+
+    public async Task<KeycloakBaseResponse<List<UserSessionResponseDto>>> GetUserSessionsAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        var uri = $"admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{userId}/sessions";
+        var request = new HttpRequestMessage(HttpMethod.Get, uri);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        return await response.HandleResponseAsync<List<UserSessionResponseDto>>();
+    }
+
+    public async Task<KeycloakBaseResponse> RevokeSessionAsync(string sessionId, CancellationToken cancellationToken = default)
+    {
+        var uri = new Uri($"admin/realms/{keyCloakConfiguration.Value.RealmName}/sessions/{sessionId}", UriKind.Relative);
+        var response = await _httpClient.DeleteAsync(uri, cancellationToken);
+        return await response.HandleResponseAsync();
+    }
+
+    public async Task<KeycloakBaseResponse> LogoutUserAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        var uri = new Uri($"admin/realms/{keyCloakConfiguration.Value.RealmName}/users/{userId}/logout", UriKind.Relative);
+        var request = new HttpRequestMessage(HttpMethod.Post, uri);
+
+        var response = await _httpClient.SendAsync(request, cancellationToken);
+        return await response.HandleResponseAsync();
+    }
+}


### PR DESCRIPTION
## What
Adds `IUserSessionManagement` with three admin API operations:
- `GetUserSessionsAsync(userId)` list all active sessions for a user
- `RevokeSessionAsync(sessionId)` delete a specific session
- `LogoutUserAsync(userId)` log the user out of all active sessions

## Changes
- `UserSessions/Contracts/IUserSessionManagement.cs` interface
- `UserSessions/Contracts/UserSessionResponseDto.cs` response DTO
- `UserSessions/UserSessionManagement.cs` implementation
- `IKeycloakManagement` / `KeycloakManagement` added `UserSessionManagement` property
- `ServiceRegistrations` registered `IUserSessionManagement`
- `UserSessionManagementTests.cs` 6 unit tests (success + failure per method)

## Usage
```csharp
var sessions = await keycloak.UserSessionManagement.GetUserSessionsAsync(userId);
await keycloak.UserSessionManagement.LogoutUserAsync(userId);
await keycloak.UserSessionManagement.RevokeSessionAsync(sessionId);
```